### PR TITLE
Implement .toHaveAttribute() with tests and docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -752,7 +752,90 @@ expect($form.find(&quot;textarea&quot;)).not.toBeEnabled();
 
 
 <h3 id="tohaveattribute">.toHaveAttribute()</h3>
-<p>This method <a href="https://github.com/franciscop/react-test/blob/master/Contributing.md"><strong>is looking for a beginner OSS contributor</strong></a> ❤️</p>
+<p>Check whether the matched elements <strong>contain</strong> the attribute &amp;&amp; value</p>
+<pre><code class="language-js">it(&#39;has attribute and value&#39;, () =&gt; {
+  const $button = (
+    &lt;button type=&quot;submit&quot; disabled&gt;
+      click
+    &lt;/button&gt;
+  );
+
+  expect($button).toHaveAttribute(&#39;type&#39;, &#39;submit&#39;);
+  expect($button).toHaveAttribute(&#39;disabled&#39;);
+});</code></pre>
+<p>It checks whether the matched elements <strong>do not contain</strong> the attribute</p>
+<pre><code class="language-js">it(&#39;does not have the attribute and value&#39;, () =&gt; {
+  const $button = (
+    &lt;button type=&quot;submit&quot; disabled&gt;
+      click
+    &lt;/button&gt;
+  );
+
+  expect($button).not.toHaveAttribute(&#39;onclick&#39;);
+  expect($button).not.toHaveAttribute(&#39;type&#39;, &#39;reset&#39;);
+});</code></pre>
+<p>It checks whether the matched elements contain the attribute and the <strong>matched regex value</strong></p>
+<pre><code class="language-js">it(&#39;checks if attribute has given regex value&#39;, () =&gt; {
+  const $button = (
+    &lt;button type=&quot;submit&quot; disabled&gt;
+      click
+    &lt;/button&gt;
+  );
+
+  // Positive assertions: all the given regex values match
+  expect($button).toHaveAttribute(&#39;type&#39;, /submit/);
+  expect($button).toHaveAttribute(&#39;type&#39;, /su?b.+/);
+  expect($button).toHaveAttribute(&#39;type&#39;, /.*/);
+
+  // Negative assertions: all the given regex values do not match
+  expect($button).not.toHaveAttribute(&#39;type&#39;, /sub/);
+  expect($button).not.toHaveAttribute(&#39;type&#39;, /su?b/);
+  expect($button).not.toHaveAttribute(&#39;type&#39;, /.*q/);
+});</code></pre>
+<p>For a list of items, it checks whether <strong>all</strong> have the same attribute &amp;&amp; value or regex</p>
+<pre><code class="language-js">const $list = $(
+  &lt;ul&gt;
+    &lt;li value=&quot;1&quot; title=&quot;list-item&quot;&gt;
+      apple
+    &lt;/li&gt;
+    &lt;li value=&quot;2&quot; title=&quot;list-item&quot;&gt;
+      apple
+    &lt;/li&gt;
+  &lt;/ul&gt;
+);
+
+// PASS
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;value&#39;);
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;title&#39;, &#39;list-item&#39;);
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;title&#39;, /list-item/);
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;title&#39;, /^li.t-.*/);
+
+// DO NOT PASS
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;error&#39;);
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;id&#39;);
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;value&#39;, &#39;1&#39;);
+expect($list.find(&#39;li&#39;)).toHaveAttribute(&#39;title&#39;, /list/);</code></pre>
+<p>For a list of items, it checks whether <strong>any do not</strong> have the same attribute &amp;&amp; value or regex</p>
+<pre><code class="language-js">const $list = $(
+  &lt;ul&gt;
+    &lt;li id=&quot;first&quot; value=&quot;1&quot; title=&quot;list-item&quot;&gt;
+      apple
+    &lt;/li&gt;
+    &lt;li value=&quot;2&quot; title=&quot;list-item&quot;&gt;
+      apple
+    &lt;/li&gt;
+  &lt;/ul&gt;
+);
+
+// PASS
+expect($list.find(&#39;li&#39;)).not.toHaveAttribute(&#39;error&#39;);
+expect($list.find(&#39;li&#39;)).not.toHaveAttribute(&#39;value&#39;, &#39;1&#39;);
+expect($list.find(&#39;li&#39;)).not.toHaveAttribute(&#39;title&#39;, /list/);
+
+// DO NOT PASS
+expect($list.find(&#39;li&#39;)).not.toHaveAttribute(&#39;value&#39;);
+expect($list.find(&#39;li&#39;)).not.toHaveAttribute(&#39;value&#39;, &#39;1&#39;);
+expect($list.find(&#39;li&#39;)).not.toHaveAttribute(&#39;title&#39;, /^list-.*/);</code></pre>
 
 
 <h3 id="tohaveclass">.toHaveClass()</h3>

--- a/src/jest-matchers/index.js
+++ b/src/jest-matchers/index.js
@@ -1,9 +1,11 @@
 import toBeEnabled from "./toBeEnabled";
+import toHaveAttribute from "./toHaveAttribute";
 import toHaveClass from "./toHaveClass";
 import toHaveText from "./toHaveText";
 
 expect.extend({
   toBeEnabled,
+  toHaveAttribute,
   toHaveClass,
-  toHaveText
+  toHaveText,
 });

--- a/src/jest-matchers/toHaveAttribute/index.js
+++ b/src/jest-matchers/toHaveAttribute/index.js
@@ -1,0 +1,45 @@
+import { normalize, getPlainTag } from '../../helpers';
+
+export default function (frag, attr, val) {
+  // To avoid double negations ¯\_(ツ)_/¯
+  this.affirmative = !this.isNot;
+
+  // Convert it into a plain array of nodes
+  frag = normalize(frag);
+
+  for (let el of frag) {
+    const attributes = [...el.attributes];
+    const base = getPlainTag(el);
+
+    // Find attribute that matches passed in attr and val
+    const found = attributes.some(({ name, value }) => {
+      if (attr !== name) return false;
+      if (val instanceof RegExp) return val.test(value);
+      if (typeof val === 'boolean') return value === '';
+      return val ? value === val : true;
+    });
+
+    // Prepare val error message
+    let valErrMessage = '';
+    if (val instanceof RegExp) valErrMessage = ` that matches ${val}`;
+    else if (val) valErrMessage = `="${val}"`;
+
+    // expect(<a href="banana.com" />).toHaveAttribute('href', 'banana.com);
+    if (this.affirmative) {
+      if (!found) {
+        const msg = `Expected ${base} to have attribute ${attr}${valErrMessage}`;
+        return { pass: false, message: () => msg };
+      }
+    }
+
+    // expect(<a href="banana.com" />).not.toHaveAttribute('orange');
+    if (this.isNot) {
+      if (found) {
+        const msg = `Expected ${base} not to have attribute ${attr}${valErrMessage}`;
+        return { pass: true, message: () => msg };
+      }
+    }
+  }
+
+  return { pass: !this.isNot };
+}

--- a/src/jest-matchers/toHaveAttribute/index.js
+++ b/src/jest-matchers/toHaveAttribute/index.js
@@ -24,20 +24,14 @@ export default function (frag, attr, val) {
     if (val instanceof RegExp) valErrMessage = ` that matches ${val}`;
     else if (val) valErrMessage = `="${val}"`;
 
-    // expect(<a href="banana.com" />).toHaveAttribute('href', 'banana.com);
-    if (this.affirmative) {
-      if (!found) {
-        const msg = `Expected ${base} to have attribute ${attr}${valErrMessage}`;
-        return { pass: false, message: () => msg };
-      }
+    if (this.affirmative && !found) {
+      const msg = `Expected ${base} to have attribute \`${attr}\`${valErrMessage}`;
+      return { pass: false, message: () => msg };
     }
 
-    // expect(<a href="banana.com" />).not.toHaveAttribute('orange');
-    if (this.isNot) {
-      if (found) {
-        const msg = `Expected ${base} not to have attribute ${attr}${valErrMessage}`;
-        return { pass: true, message: () => msg };
-      }
+    if (this.isNot && found) {
+      const msg = `Expected ${base} not to have attribute \`${attr}\`${valErrMessage}`;
+      return { pass: true, message: () => msg };
     }
   }
 

--- a/src/jest-matchers/toHaveAttribute/readme.md
+++ b/src/jest-matchers/toHaveAttribute/readme.md
@@ -1,3 +1,127 @@
 ### .toHaveAttribute()
 
-This method [**is looking for a beginner OSS contributor**](https://github.com/franciscop/react-test/blob/master/Contributing.md) ❤️
+Check whether the matched elements all **contain the attribute && value**
+
+```js
+it('has attribute and value', () => {
+  const $button = (
+    <button type="submit" disabled>
+      click
+    </button>
+  );
+
+  expect($button).toHaveAttribute('type', 'submit');
+  expect($button).toHaveAttribute('disabled');
+});
+```
+
+It checks whether the matched elements **do not contain the attribute**
+
+```js
+it('does not have the attribute and value', () => {
+  const $button = (
+    <button type="submit" disabled>
+      click
+    </button>
+  );
+
+  expect($button).not.toHaveAttribute('onclick');
+  expect($button).not.toHaveAttribute('type', 'reset');
+});
+```
+
+It checks whether the matched elements **contain the attribute and the matched regex value**
+
+```js
+it('checks if attribute has given regex value', () => {
+  const $button = (
+    <button type="submit" disabled>
+      click
+    </button>
+  );
+
+  // Positive assertions: all the given regex values match
+  expect($button).toHaveAttribute('type', /submit/);
+  expect($button).toHaveAttribute('type', /su?b.+/);
+  expect($button).toHaveAttribute('type', /.*/);
+
+  // Negative assertions: all the given regex values do not match
+  expect($button).not.toHaveAttribute('type', /sub/);
+  expect($button).not.toHaveAttribute('type', /su?b/);
+  expect($button).not.toHaveAttribute('type', /.*q/);
+});
+```
+
+For a list of items, it checks whether **all have the same attribute && value or regex**
+
+```js
+const $list = $(
+  <ul>
+    <li value="1" title="list-item">
+      apple
+    </li>
+    <li value="2" title="list-item">
+      apple
+    </li>
+  </ul>
+);
+
+// Passes; all of them have the given attribute
+expect($list.find('li')).toHaveAttribute('value');
+
+// Passes; all of them have the given attribute && value
+expect($list.find('li')).toHaveAttribute('title', 'list-item');
+
+// Passes; all of them have the given attribute && value
+expect($list.find('li')).toHaveAttribute('title', /list-item/);
+expect($list.find('li')).toHaveAttribute('title', /^li.t-.*/);
+
+// DO NOT PASS
+
+// ERROR! Because none of the list elements have attribute id
+expect($list.find('li')).toHaveAttribute('error');
+
+// ERROR! Because only all the list item elements do not have an attribute apple
+expect($list.find('li')).toHaveAttribute('id');
+
+// ERROR! Because only one of the list item elements have a value of 1
+expect($list.find('li')).toHaveAttribute('value', '1');
+
+// ERROR! Because none one of the list item elements match the regex value
+expect($list.find('li')).toHaveAttribute('title', /list/);
+```
+
+For a list of items, it checks whether **do not have the same attribute && value or regex**
+
+```js
+const $list = $(
+  <ul>
+    <li id="first" value="1" title="list-item">
+      apple
+    </li>
+    <li value="2" title="list-item">
+      apple
+    </li>
+  </ul>
+);
+
+// Passes; none of them have the given attribute
+expect($list.find('li')).not.toHaveAttribute('error');
+
+// Passes; not all of them have the given attribute && value
+expect($list.find('li')).not.toHaveAttribute('value', '1');
+
+// Passes; not all of them have the given attribute && match the regex value
+expect($list.find('li')).not.toHaveAttribute('title', /list/);
+
+// DO NOT PASS
+
+// ERROR! Because both list item elements have attribute value
+expect($list.find('li')).not.toHaveAttribute('value');
+
+// ERROR! Because at least one list item element has attribute value that equals 1
+expect($list.find('li')).not.toHaveAttribute('value', '1');
+
+// ERROR! Because at least one list item element has attribute value that equals 1
+expect($list.find('li')).not.toHaveAttribute('title', /^list-.*/);
+```

--- a/src/jest-matchers/toHaveAttribute/readme.md
+++ b/src/jest-matchers/toHaveAttribute/readme.md
@@ -1,6 +1,6 @@
 ### .toHaveAttribute()
 
-Check whether the matched elements all **contain the attribute && value**
+Check whether the matched elements **contain** the attribute && value
 
 ```js
 it('has attribute and value', () => {
@@ -15,7 +15,7 @@ it('has attribute and value', () => {
 });
 ```
 
-It checks whether the matched elements **do not contain the attribute**
+It checks whether the matched elements **do not contain** the attribute
 
 ```js
 it('does not have the attribute and value', () => {
@@ -30,7 +30,7 @@ it('does not have the attribute and value', () => {
 });
 ```
 
-It checks whether the matched elements **contain the attribute and the matched regex value**
+It checks whether the matched elements contain the attribute and the **matched regex value**
 
 ```js
 it('checks if attribute has given regex value', () => {
@@ -52,7 +52,7 @@ it('checks if attribute has given regex value', () => {
 });
 ```
 
-For a list of items, it checks whether **all have the same attribute && value or regex**
+For a list of items, it checks whether **all** have the same attribute && value or regex
 
 ```js
 const $list = $(
@@ -66,32 +66,20 @@ const $list = $(
   </ul>
 );
 
-// Passes; all of them have the given attribute
+// PASS
 expect($list.find('li')).toHaveAttribute('value');
-
-// Passes; all of them have the given attribute && value
 expect($list.find('li')).toHaveAttribute('title', 'list-item');
-
-// Passes; all of them have the given attribute && value
 expect($list.find('li')).toHaveAttribute('title', /list-item/);
 expect($list.find('li')).toHaveAttribute('title', /^li.t-.*/);
 
 // DO NOT PASS
-
-// ERROR! Because none of the list elements have attribute id
 expect($list.find('li')).toHaveAttribute('error');
-
-// ERROR! Because only all the list item elements do not have an attribute apple
 expect($list.find('li')).toHaveAttribute('id');
-
-// ERROR! Because only one of the list item elements have a value of 1
 expect($list.find('li')).toHaveAttribute('value', '1');
-
-// ERROR! Because none one of the list item elements match the regex value
 expect($list.find('li')).toHaveAttribute('title', /list/);
 ```
 
-For a list of items, it checks whether **do not have the same attribute && value or regex**
+For a list of items, it checks whether **any do not** have the same attribute && value or regex
 
 ```js
 const $list = $(
@@ -105,23 +93,13 @@ const $list = $(
   </ul>
 );
 
-// Passes; none of them have the given attribute
+// PASS
 expect($list.find('li')).not.toHaveAttribute('error');
-
-// Passes; not all of them have the given attribute && value
 expect($list.find('li')).not.toHaveAttribute('value', '1');
-
-// Passes; not all of them have the given attribute && match the regex value
 expect($list.find('li')).not.toHaveAttribute('title', /list/);
 
 // DO NOT PASS
-
-// ERROR! Because both list item elements have attribute value
 expect($list.find('li')).not.toHaveAttribute('value');
-
-// ERROR! Because at least one list item element has attribute value that equals 1
 expect($list.find('li')).not.toHaveAttribute('value', '1');
-
-// ERROR! Because at least one list item element has attribute value that equals 1
 expect($list.find('li')).not.toHaveAttribute('title', /^list-.*/);
 ```

--- a/src/jest-matchers/toHaveAttribute/test.js
+++ b/src/jest-matchers/toHaveAttribute/test.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import $ from '../../';
+import '../index.js';
+
+const $button = $(<button type="submit" />);
+const $input = $(<input type="text" name="name" required />);
+
+describe('.toHaveAttribute()', () => {
+  it('works for a simple case', () => {
+    expect($button).toHaveAttribute('type', 'submit');
+    expect($input).toHaveAttribute('type', 'text');
+    expect($input).toHaveAttribute('name', 'name');
+    expect($input).toHaveAttribute('required', true);
+    expect($input).toHaveAttribute('required');
+  });
+
+  it('requires an HTMLelement', () => {
+    const msg = 'expect() should receive an HTMLElement or React Test instance';
+    expect(() => expect(null).toHaveAttribute('kiwi')).toThrow(msg);
+    expect(() => expect('random').toHaveAttribute('kiwi')).toThrow(msg);
+  });
+
+  it('requires a valid instance', () => {
+    expect(() => expect({}).toHaveAttribute('kiwi')).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    );
+  });
+
+  it('requires the correct attr name', () => {
+    expect(() => expect($button).toHaveAttribute('error')).toThrow(
+      'Expected <button type="submit"> to have attribute error'
+    );
+  });
+
+  it('requires the correct attr value', () => {
+    expect(() => expect($button).toHaveAttribute('type', 'reset')).toThrow(
+      'Expected <button type="submit"> to have attribute type="reset"'
+    );
+  });
+
+  it('fails if attr is found when not expected', () => {
+    expect(() => expect($button).not.toHaveAttribute('type')).toThrow(
+      'Expected <button type="submit"> not to have attribute type'
+    );
+  });
+
+  it('fails if attr with correct value is found when not expected', () => {
+    expect(() => expect($button).not.toHaveAttribute('type', 'submit')).toThrow(
+      'Expected <button type="submit"> not to have attribute type="submit"'
+    );
+  });
+
+  describe('regex', () => {
+    it('handles regex for values', () => {
+      expect($input).toHaveAttribute('type', /text/);
+      expect($input).toHaveAttribute('type', /te.+/);
+      expect($input).toHaveAttribute('type', /.*/);
+    });
+
+    it('fails when regex is invalid', () => {
+      expect(() => expect($input).toHaveAttribute('type', /texax./)).toThrow(
+        'Expected <input type="text" name="name" required=""> to have attribute type that matches /texax./'
+      );
+    });
+
+    it('handles negated regex values', () => {
+      expect($input).not.toHaveAttribute('type', /texax./);
+    });
+
+    it('fails when negated regex values exist', () => {
+      expect(() => expect($input).not.toHaveAttribute('type', /tex.+/)).toThrow(
+        'Expected <input type="text" name="name" required=""> not to have attribute type that matches /tex.+/'
+      );
+    });
+  });
+
+  describe('multiple elements', () => {
+    const $list = $(
+      <ul>
+        <li id="first" value="1" title="list-item">
+          apple
+        </li>
+        <li value="2" title="list-item">
+          apple
+        </li>
+      </ul>
+    );
+
+    it('requires all elements to have the same attribute', () => {
+      expect($list.find('li')).toHaveAttribute('value');
+      expect(() => expect($list.find('li')).toHaveAttribute('id')).toThrow(
+        'Expected <li value="2" title="list-item"> to have attribute id'
+      );
+    });
+
+    it('requires all elements to have the same attribute && value', () => {
+      expect(() =>
+        expect($list.find('li')).toHaveAttribute('value', '1')
+      ).toThrow(
+        'Expected <li value="2" title="list-item"> to have attribute value="1"'
+      );
+    });
+
+    it('requires all elements to not have the same attribute', () => {
+      expect($list.find('li')).not.toHaveAttribute('hi');
+      expect(() => expect($list.find('li')).not.toHaveAttribute('id')).toThrow(
+        'Expected <li id="first" value="1" title="list-item"> not to have attribute id'
+      );
+    });
+
+    it('requires all elements to not have the same attribute && value', () => {
+      expect($list.find('li')).not.toHaveAttribute('title', 'order');
+      // Returns the first unmatched element
+      expect(() =>
+        expect($list.find('li')).not.toHaveAttribute('title', 'list-item')
+      ).toThrow(
+        'Expected <li id="first" value="1" title="list-item"> not to have attribute title="list-item"'
+      );
+    });
+  });
+});

--- a/src/jest-matchers/toHaveAttribute/test.js
+++ b/src/jest-matchers/toHaveAttribute/test.js
@@ -28,25 +28,25 @@ describe('.toHaveAttribute()', () => {
 
   it('requires the correct attr name', () => {
     expect(() => expect($button).toHaveAttribute('error')).toThrow(
-      'Expected <button type="submit"> to have attribute error'
+      'Expected <button type="submit"> to have attribute `error`'
     );
   });
 
   it('requires the correct attr value', () => {
     expect(() => expect($button).toHaveAttribute('type', 'reset')).toThrow(
-      'Expected <button type="submit"> to have attribute type="reset"'
+      'Expected <button type="submit"> to have attribute `type`="reset"'
     );
   });
 
   it('fails if attr is found when not expected', () => {
     expect(() => expect($button).not.toHaveAttribute('type')).toThrow(
-      'Expected <button type="submit"> not to have attribute type'
+      'Expected <button type="submit"> not to have attribute `type`'
     );
   });
 
   it('fails if attr with correct value is found when not expected', () => {
     expect(() => expect($button).not.toHaveAttribute('type', 'submit')).toThrow(
-      'Expected <button type="submit"> not to have attribute type="submit"'
+      'Expected <button type="submit"> not to have attribute `type`="submit"'
     );
   });
 
@@ -59,7 +59,7 @@ describe('.toHaveAttribute()', () => {
 
     it('fails when regex is invalid', () => {
       expect(() => expect($input).toHaveAttribute('type', /texax./)).toThrow(
-        'Expected <input type="text" name="name" required=""> to have attribute type that matches /texax./'
+        'Expected <input type="text" name="name" required=""> to have attribute `type` that matches /texax./'
       );
     });
 
@@ -69,7 +69,7 @@ describe('.toHaveAttribute()', () => {
 
     it('fails when negated regex values exist', () => {
       expect(() => expect($input).not.toHaveAttribute('type', /tex.+/)).toThrow(
-        'Expected <input type="text" name="name" required=""> not to have attribute type that matches /tex.+/'
+        'Expected <input type="text" name="name" required=""> not to have attribute `type` that matches /tex.+/'
       );
     });
   });
@@ -89,7 +89,7 @@ describe('.toHaveAttribute()', () => {
     it('requires all elements to have the same attribute', () => {
       expect($list.find('li')).toHaveAttribute('value');
       expect(() => expect($list.find('li')).toHaveAttribute('id')).toThrow(
-        'Expected <li value="2" title="list-item"> to have attribute id'
+        'Expected <li value="2" title="list-item"> to have attribute `id`'
       );
     });
 
@@ -97,14 +97,14 @@ describe('.toHaveAttribute()', () => {
       expect(() =>
         expect($list.find('li')).toHaveAttribute('value', '1')
       ).toThrow(
-        'Expected <li value="2" title="list-item"> to have attribute value="1"'
+        'Expected <li value="2" title="list-item"> to have attribute `value`="1"'
       );
     });
 
     it('requires all elements to not have the same attribute', () => {
       expect($list.find('li')).not.toHaveAttribute('hi');
       expect(() => expect($list.find('li')).not.toHaveAttribute('id')).toThrow(
-        'Expected <li id="first" value="1" title="list-item"> not to have attribute id'
+        'Expected <li id="first" value="1" title="list-item"> not to have attribute `id`'
       );
     });
 
@@ -114,7 +114,7 @@ describe('.toHaveAttribute()', () => {
       expect(() =>
         expect($list.find('li')).not.toHaveAttribute('title', 'list-item')
       ).toThrow(
-        'Expected <li id="first" value="1" title="list-item"> not to have attribute title="list-item"'
+        'Expected <li id="first" value="1" title="list-item"> not to have attribute `title`="list-item"'
       );
     });
   });


### PR DESCRIPTION
Related Issue: #18 
- Implements .toHaveAttribute() Jest matcher method
- Adds tests to handle multiple cases
- Adds a README that includes the multiple cases
- Ran npm test to make sure nothing breaks