### PR TITLE
Add Counter example to main readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,19 +5,17 @@
 Expressive testing library for React to make sure your code works as expected:
 
 ```js
-import $ from "react-test";
+import $ from 'react-test';
 
-it("increments when clicked", async () => {
+it('increments when clicked', async () => {
   const counter = $(<Counter />);
-  expect(counter).toHaveText("0");
+  expect(counter).toHaveText('0');
   await counter.click();
-  expect(counter).toHaveText("1");
+  expect(counter).toHaveText('1');
 });
 ```
 
 The `react-test` syntax follows a similar schema to jQuery so it's very easy to write expressive tests. The best way to test declarative code is with an imperative library.
-
-
 
 ## Getting Started
 
@@ -37,29 +35,40 @@ npm install react-test --save-dev
 Finally you can write tests. Let's say you have [the `<Counter />` component from this example](#counter) and you want to test it to make sure it works as expected:
 
 ```js
+// Counter.js
+import React, { useState } from 'react';
+
+export default function Counter() {
+  const [counter, setCounter] = useState(0);
+  const increment = () => setCounter(counter + 1);
+  return <button onClick={increment}>{counter}</button>;
+}
+```
+
+```js
 // src/Counter.test.js
-import React from "react";
-import $ from "react-test";
-import Counter from "./Counter";
+import React from 'react';
+import $ from 'react-test';
+import Counter from './Counter';
 
-describe("Counter.js", () => {
-  it("is initialized to 0", () => {
+describe('Counter.js', () => {
+  it('is initialized to 0', () => {
     const counter = $(<Counter />);
-    expect(counter.text()).toBe("0");
+    expect(counter.text()).toBe('0');
   });
 
-  it("can be incremented with a click", async () => {
+  it('can be incremented with a click', async () => {
     const counter = $(<Counter />);
     await counter.click();
-    expect(counter.text()).toBe("1");
+    expect(counter.text()).toBe('1');
   });
 
-  it("can be incremented multiple times", async () => {
+  it('can be incremented multiple times', async () => {
     const counter = $(<Counter />);
     await counter.click();
     await counter.click();
     await counter.click();
-    expect(counter.text()).toBe("3");
+    expect(counter.text()).toBe('3');
   });
 });
 ```
@@ -70,8 +79,6 @@ Finally run the tests with Jest:
 npm run test
 ```
 
-
-
 ### Basics of testing
 
 React applications are divided in components, and these components can be tested either individually or in group. Self-contained components are easier to test, document and debug.
@@ -79,10 +86,10 @@ React applications are divided in components, and these components can be tested
 For example, a plain button can be defined with a callback function, and change colors depending on the `primary` attribute:
 
 ```js
-import React from "react";
+import React from 'react';
 
-export default function Button ({ primary, onClick, children }) {
-  const background = primary ? "blue" : "gray";
+export default function Button({ primary, onClick, children }) {
+  const background = primary ? 'blue' : 'gray';
   return (
     <button onClick={onClick} style={{ background }}>
       {children}
@@ -94,19 +101,19 @@ export default function Button ({ primary, onClick, children }) {
 Then we can test it with `react-test` by creating a `Button.test.js` file and adding some assertions:
 
 ```js
-import React from "react";
-import $ from "react-test";
-import Button from "./Button";
+import React from 'react';
+import $ from 'react-test';
+import Button from './Button';
 
-describe("Button.js", () => {
-  it("has different backgrounds depending on the props", () => {
+describe('Button.js', () => {
+  it('has different backgrounds depending on the props', () => {
     const $button = $(<Button>Hello</Button>);
-    expect($button).toHaveStyle("background", "gray");
+    expect($button).toHaveStyle('background', 'gray');
     const $primary = $(<Button primary>Hello</Button>);
-    expect($primary).toHaveStyle("background", "blue");
+    expect($primary).toHaveStyle('background', 'blue');
   });
 
-  it("can be clicked", async () => {
+  it('can be clicked', async () => {
     const fn = jest.fn();
     const $button = $(<Button onClick={fn}>Hello</Button>);
     expect(fn).not.toBeCalled();
@@ -123,7 +130,7 @@ describe("Button.js", () => {
       </Button>
     );
     await $button.click();
-    expect(fn).not.toBeCalled();   // ERROR!
+    expect(fn).not.toBeCalled(); // ERROR!
   });
 });
 ```
@@ -131,10 +138,10 @@ describe("Button.js", () => {
 Great! All of our tests are working except for the last one. Now we can go back to our component and fix it:
 
 ```js
-import React from "react";
+import React from 'react';
 
-export default function Button ({ primary, onClick, children, ...props }) {
-  const background = primary ? "blue" : "gray";
+export default function Button({ primary, onClick, children, ...props }) {
+  const background = primary ? 'blue' : 'gray';
   return (
     <button onClick={onClick} style={{ background }} {...props}>
       {children}
@@ -143,14 +150,11 @@ export default function Button ({ primary, onClick, children, ...props }) {
 }
 ```
 
-
-
 ### FAQ
 
 #### Is this an official Facebook/React library?
 
 No. This follows the community convention of calling a library related to React as `react-NAME`. It is made [by these contributors](https://github.com/franciscop/react-test/graphs/contributors) without any involvement of Facebook or [React](https://reactjs.org/).
-
 
 #### How can I contribute?
 
@@ -158,18 +162,15 @@ Thanks! Please read the [Contributing Guide](./Contributing.md) where we explain
 
 I will try to help as much as possible on the PRs.
 
-
 #### I have a problem, how do I fix it?
 
 Don't sweat it, [just open an issue](https://github.com/franciscop/react-test/issues/new). React Test is in an early phase with incomplete documentation so feel free to read the code or ask directly in the issues.
 
 This will change once the library is more stable, there's more documentation and if the community grows (maybe a chat, or reddit group, or ...).
 
-
 #### How did you get `react-test`?
 
 I've [written a blog post about this](https://medium.com/server-for-node-js/getting-a-great-npm-name-b0b2b27a0e1b), but the gist of it is that the npm package was taken [by Deepstream.io](https://deepstream.io/) before but not used. So I asked politely and they allowed me to use it.
-
 
 #### How is this different from [React Testing Library](https://testing-library.com/docs/react-testing-library/intro)?
 
@@ -179,27 +180,25 @@ The syntax follows jQuery-style chaining:
 
 ```js
 // react-test
-import $ from "react-test";
-test("Increments when clicked", async () => {
+import $ from 'react-test';
+test('Increments when clicked', async () => {
   const $counter = $(<Counter />);
-  expect($counter).toHaveText("0");
+  expect($counter).toHaveText('0');
   await $counter.click();
-  expect($counter).toHaveText("1");
+  expect($counter).toHaveText('1');
 });
 
 // react testing library
-import { render, fireEvent } from "@testing-library/react"
-test("Increments when clicked", () => {
+import { render, fireEvent } from '@testing-library/react';
+test('Increments when clicked', () => {
   const { getByRole, container } = render(<Counter />);
-  expect(container).toHaveTextContent("0");
-  fireEvent.click(getByRole("button"));
-  expect(container).toHaveTextContent("1");
+  expect(container).toHaveTextContent('0');
+  fireEvent.click(getByRole('button'));
+  expect(container).toHaveTextContent('1');
 });
 ```
 
 React Test is a work in progress, so if you are writing tests for production right now please use one of the better known alternatives.
-
-
 
 #### jQuery syntax, ewwh
 
@@ -208,11 +207,11 @@ That's not really a question! But if for some reason you deeply despise those do
 ```js
 import render from 'react-test';
 
-test("Increments when clicked", async () => {
+test('Increments when clicked', async () => {
   const counter = render(<Counter />);
-  expect(counter).toHaveText("0");
+  expect(counter).toHaveText('0');
   await counter.click();
-  expect(counter).toHaveText("1");
+  expect(counter).toHaveText('1');
 });
 ```
 


### PR DESCRIPTION
The main readme documentation when viewed via GitHub contains a dead link to the Container example, which left me a bit confused, as having the sample code helps provide context to the example test suite. 

While on the actual site I noticed the link works, referencing to the readme located in the Counter example directory. Even so, it felt a bit unnecessary/annoying to be taken to a very distant section of the page to view the example, then having to scroll back up.

Therefore, I would like to copy a sample of the Counter code to the main readme to avoid confusion for users on GitHub and improve reading for users on the site.