### PR TITLE
Implement JavaScript Standard Style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,24 +4,24 @@ module.exports = {
     commonjs: true,
     es6: true,
     browser: true,
-    "jest/globals": true
+    'jest/globals': true
   },
-  extends: ["eslint:recommended", "plugin:react/recommended"],
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
   parserOptions: {
     ecmaFeatures: { jsx: true },
     ecmaVersion: 2018,
-    sourceType: "module"
+    sourceType: 'module'
   },
-  plugins: ["react", "jest"],
+  plugins: ['react', 'jest'],
   settings: {
-    react: { version: "detect" }
+    react: { version: 'detect' }
   },
   rules: {
-    "jest/no-disabled-tests": "warn",
-    "jest/no-focused-tests": "error",
-    "jest/no-identical-title": "error",
-    "jest/prefer-to-have-length": "warn",
-    "jest/valid-expect": "error",
-    "react/prop-types": "off"
+    'jest/no-disabled-tests': 'warn',
+    'jest/no-focused-tests': 'error',
+    'jest/no-identical-title': 'error',
+    'jest/prefer-to-have-length': 'warn',
+    'jest/valid-expect': 'error',
+    'react/prop-types': 'off'
   }
-};
+}

--- a/Contributing.md
+++ b/Contributing.md
@@ -39,30 +39,34 @@ You can follow some of the existing methods in src/[METHOD]. We'd recommended to
 Tests should make sure that the feature work, with some diverse examples if possible. The normal flow is defining some component to be tested, then execute some operation against it and assert the result:
 
 ```js
-it("Has the correct html without selector", async () => {
+it('Has the correct html without selector', async () => {
   const $hello = $(
     <div>
       <button>Hello</button>
     </div>
   );
-  expect($hello.children().first().nodeName).toBe("BUTTON");
+  expect($hello.children().first().nodeName).toBe('BUTTON');
 });
 ```
 
 You can also keep it in a variable if you want to assert multiple things:
 
 ```js
-it("Has the correct html without selector", async () => {
+it('Has the correct html without selector', async () => {
   const $hello = $(
     <div>
       <button>Hello</button>
     </div>
   );
   const $button = $hello.children();
-  expect($button.first().nodeName).toBe("BUTTON");
-  expect($button.text()).toBe("Hello");
+  expect($button.first().nodeName).toBe('BUTTON');
+  expect($button.text()).toBe('Hello');
 });
 ```
+
+## Style Guide
+
+We use [**JavaScript Standard Style**](https://standardjs.com/) for our style guide, linter, and formatter. The linter will run automatically as part of `npm start` and `npm test`, or you can manually run `npm run lint`. You can then automatically format code with `npm run fix`. Any changes unable to be automatically formatted, will be output to the console for manual changes.
 
 ## About "up for grabs"
 

--- a/output.test.js
+++ b/output.test.js
@@ -1,16 +1,16 @@
-import React, { useEffect } from "react";
-import $ from "./index.min.js";
-import "babel-polyfill";
+import React, { useEffect } from 'react'
+import $ from './index.min.js'
+import 'babel-polyfill'
 
-describe("output", () => {
-  it("can use hooks", () => {
+describe('output', () => {
+  it('can use hooks', () => {
     const CompWithHook = () => {
       useEffect(() => {
         // Nothing going on here
-      }, []);
-      return <div>Hi</div>;
-    };
-    const $hooked = $(<CompWithHook />);
-    expect($hooked.html()).toBe(`<div>Hi</div>`);
-  });
-});
+      }, [])
+      return <div>Hi</div>
+    }
+    const $hooked = $(<CompWithHook />)
+    expect($hooked.html()).toBe('<div>Hi</div>')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "build": "rollup -c",
     "docs": "node ./scripts/server.js",
     "size": "echo $(gzip -c index.min.js | wc -c) bytes",
-    "start": "jest --coverage --watch",
-    "test": "jest --coverage --detectOpenHandles"
+    "start": "standard && jest --coverage --watch",
+    "test": "standard && jest --coverage --detectOpenHandles",
+    "lint": "standard",
+    "fix": "standard --fix --verbose"
   },
   "keywords": [
     "react",
@@ -52,7 +54,8 @@
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-terser": "^5.2.0"
+    "rollup-plugin-terser": "^5.2.0",
+    "standard": "^16.0.4"
   },
   "babel": {
     "presets": [
@@ -69,5 +72,13 @@
       "@babel/preset-react"
     ],
     "plugins": []
+  },
+  "standard": {
+    "globals": [
+      "Event"
+    ],
+    "env": [
+      "jest"
+    ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,30 +1,30 @@
-import commonjs from "rollup-plugin-commonjs";
-import nodeResolve from "rollup-plugin-node-resolve";
-import json from "rollup-plugin-json";
-import { terser } from "rollup-plugin-terser";
+import commonjs from 'rollup-plugin-commonjs'
+import nodeResolve from 'rollup-plugin-node-resolve'
+import json from 'rollup-plugin-json'
+import { terser } from 'rollup-plugin-terser'
 
 export default {
-  input: "src/index.js",
+  input: 'src/index.js',
   output: {
-    file: "index.min.js",
-    name: "$",
-    format: "umd",
+    file: 'index.min.js',
+    name: '$',
+    format: 'umd',
     // This is because we use default and named exports at the same time. The
     // commonjs will have to import with ['default'], but no problem for ESM
-    exports: "named",
+    exports: 'named',
 
     globals: {
-      window: "Window",
-      react: "React",
-      "react-dom": "ReactDOM",
-      "react-dom/test-utils": "testUtils"
+      window: 'Window',
+      react: 'React',
+      'react-dom': 'ReactDOM',
+      'react-dom/test-utils': 'testUtils'
     }
   },
-  external: ["window", "react", "react-dom", "react-dom/test-utils"],
+  external: ['window', 'react', 'react-dom', 'react-dom/test-utils'],
   plugins: [
     nodeResolve({ preferBuiltins: true }),
-    commonjs({ namedExports: { "react-dom/test-utils": ["act"] } }),
+    commonjs({ namedExports: { 'react-dom/test-utils': ['act'] } }),
     json(),
     terser()
   ]
-};
+}

--- a/src/examples/Counter/Counter.js
+++ b/src/examples/Counter/Counter.js
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React, { useState } from 'react'
 
-export default function Counter() {
-  const [counter, setCounter] = useState(0);
-  const increment = () => setCounter(counter + 1);
-  return <button onClick={increment}>{counter}</button>;
+export default function Counter () {
+  const [counter, setCounter] = useState(0)
+  const increment = () => setCounter(counter + 1)
+  return <button onClick={increment}>{counter}</button>
 }

--- a/src/examples/Counter/Counter.test.js
+++ b/src/examples/Counter/Counter.test.js
@@ -1,33 +1,33 @@
 // Counter.test.js;
-import React from "react";
-import $ from "../../";
-import Counter from "./Counter";
+import React from 'react'
+import $ from '../../'
+import Counter from './Counter'
 
-describe("Counter.js", () => {
-  it("starts with 0", () => {
-    const counter = $(<Counter />);
-    expect(counter).toHaveText("0");
-  });
+describe('Counter.js', () => {
+  it('starts with 0', () => {
+    const counter = $(<Counter />)
+    expect(counter).toHaveText('0')
+  })
 
-  it("increments when clicked", async () => {
-    const counter = $(<Counter />);
-    await counter.click();
-    expect(counter).toHaveText("1");
-  });
+  it('increments when clicked', async () => {
+    const counter = $(<Counter />)
+    await counter.click()
+    expect(counter).toHaveText('1')
+  })
 
-  it("can be incremented multiple times", async () => {
-    const counter = $(<Counter />);
-    await counter.click();
-    await counter.click();
-    await counter.click();
-    expect(counter).toHaveText("3");
-  });
+  it('can be incremented multiple times', async () => {
+    const counter = $(<Counter />)
+    await counter.click()
+    await counter.click()
+    await counter.click()
+    expect(counter).toHaveText('3')
+  })
 
-  it("remains independent of other components", async () => {
-    const counter1 = $(<Counter />);
-    const counter2 = $(<Counter />);
-    await counter2.click();
-    expect(counter1).toHaveText("0");
-    expect(counter2).toHaveText("1");
-  });
-});
+  it('remains independent of other components', async () => {
+    const counter1 = $(<Counter />)
+    const counter2 = $(<Counter />)
+    await counter2.click()
+    expect(counter1).toHaveText('0')
+    expect(counter2).toHaveText('1')
+  })
+})

--- a/src/helpers/getPlainTag.js
+++ b/src/helpers/getPlainTag.js
@@ -3,9 +3,9 @@
 
 export default el => {
   // Get the full HTML tag WITHOUT its contents
-  const html = el.cloneNode(false).outerHTML;
+  const html = el.cloneNode(false).outerHTML
 
   // Regex should NOT be used generally for HTML. We make an exception here
   // because it's a very strict regex out of a very well defined output string
-  return html.replace(/<\/[a-zA-Z0-9-]+>$/, "");
-};
+  return html.replace(/<\/[a-zA-Z0-9-]+>$/, '')
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,4 +1,4 @@
-import normalize from "./normalize";
-import getPlainTag from "./getPlainTag";
+import normalize from './normalize'
+import getPlainTag from './getPlainTag'
 
 export { normalize, getPlainTag }

--- a/src/helpers/normalize.js
+++ b/src/helpers/normalize.js
@@ -1,35 +1,35 @@
 // [INTERNAL USE ONLY]
 // normalize()
 // Take the expect() arg and returns a clean array of HTMLElements
-import render from "../methods/render";
+import render from '../methods/render'
 
 export default frag => {
   if (!frag) {
     throw new Error(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
+      'expect() should receive an HTMLElement or React Test instance'
+    )
   }
 
   // Convert a raw element to
   if (frag.$$typeof) {
-    const parts = render(frag);
-    frag = parts[0];
+    const parts = render(frag)
+    frag = parts[0]
   }
 
   // For now get the first one, consider looping later
-  if (frag.toArray) frag = frag.toArray();
+  if (frag.toArray) frag = frag.toArray()
 
   // It's a single node
-  if (!Array.isArray(frag)) frag = [frag];
+  if (!Array.isArray(frag)) frag = [frag]
 
   frag.forEach(node => {
     // Make sure it's an HTML node
     if (!node.nodeName) {
       throw new Error(
-        "expect() should receive an HTMLElement or React Test instance"
-      );
+        'expect() should receive an HTMLElement or React Test instance'
+      )
     }
-  });
+  })
 
-  return frag;
-};
+  return frag
+}

--- a/src/helpers/until.js
+++ b/src/helpers/until.js
@@ -1,31 +1,31 @@
-import { act } from "react-dom/test-utils";
-const delay = time => new Promise(done => setTimeout(done, time));
+import { act } from 'react-dom/test-utils'
+const delay = (time) => new Promise((resolve) => setTimeout(resolve, time))
 
-const untilCallback = async cb => {
-  let value = await cb();
+const untilCallback = async (cb) => {
+  let value = await cb()
   while (!value) {
     await act(async () => {
-      await delay(50);
-      value = await cb();
-    });
+      await delay(50)
+      value = await cb()
+    })
   }
-  return value;
-};
+  return value
+}
 
-const untilObject = obj => {
+const untilObject = (obj) => {
   const getter = (target, key) => {
-    return (...args) => untilCallback(() => obj[key](...args));
-  };
-  return new Proxy(obj, { get: getter });
-};
-
-const until = arg => {
-  if (typeof arg === "function") {
-    return untilCallback(arg);
+    return (...args) => untilCallback(() => obj[key](...args))
   }
-  if (typeof arg === "object") {
-    return untilObject(arg);
-  }
-};
+  return new Proxy(obj, { get: getter })
+}
 
-export default until;
+const until = (arg) => {
+  if (typeof arg === 'function') {
+    return untilCallback(arg)
+  }
+  if (typeof arg === 'object') {
+    return untilObject(arg)
+  }
+}
+
+export default until

--- a/src/helpers/until.test.js
+++ b/src/helpers/until.test.js
@@ -1,46 +1,46 @@
-import React, { useState } from "react";
-import $, { until } from "../";
-import "babel-polyfill";
+import React, { useState } from 'react'
+import $, { until } from '../'
+import 'babel-polyfill'
 
-describe("until()", () => {
-  it("passes fast with true", async () => {
-    const init = new Date();
-    await until(() => true);
-    expect(new Date() - init).toBeLessThan(100);
-  });
+describe('until()', () => {
+  it('passes fast with true', async () => {
+    const init = new Date()
+    await until(() => true)
+    expect(new Date() - init).toBeLessThan(100)
+  })
 
-  it("works with a callback", async () => {
-    let pass = false;
+  it('works with a callback', async () => {
+    let pass = false
     setTimeout(() => {
-      pass = true;
-    }, 100);
-    expect(pass).toBe(false);
-    await until(() => pass);
-    expect(pass).toBe(true);
-  });
+      pass = true
+    }, 100)
+    expect(pass).toBe(false)
+    await until(() => pass)
+    expect(pass).toBe(true)
+  })
 
-  it("works with an object", async () => {
-    let pass = false;
-    const obj = { is: param => (pass ? param : false) };
+  it('works with an object', async () => {
+    let pass = false
+    const obj = { is: param => (pass ? param : false) }
     setTimeout(() => {
-      pass = true;
-    }, 100);
+      pass = true
+    }, 100)
 
-    expect(pass).toBe(false);
-    await until(obj).is("abc");
-    expect(pass).toBe(true);
-  });
+    expect(pass).toBe(false)
+    await until(obj).is('abc')
+    expect(pass).toBe(true)
+  })
 
-  it("works with a component", async () => {
+  it('works with a component', async () => {
     const Timer = () => {
-      const [out, setOut] = useState(false);
-      if (!out) setTimeout(() => setOut(true), 100);
-      return <div className={out ? "active" : null}>Blah</div>;
-    };
-    const timer = $(<Timer />);
+      const [out, setOut] = useState(false)
+      if (!out) setTimeout(() => setOut(true), 100)
+      return <div className={out ? 'active' : null}>Blah</div>
+    }
+    const timer = $(<Timer />)
 
-    expect(timer.is(".active")).toBe(false);
-    await until(timer).is(".active");
-    expect(timer.is(".active")).toBe(true);
-  });
-});
+    expect(timer.is('.active')).toBe(false)
+    await until(timer).is('.active')
+    expect(timer.is('.active')).toBe(true)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,29 @@
-import "array-flat-polyfill";
-import "./jest-matchers";
+import 'array-flat-polyfill'
+import './jest-matchers'
 
-import $ from "./methods/constructor";
+import $ from './methods/constructor'
 
 // Import all of the methods which will modify the $.prototype straight away
-import "./methods/attr";
-import "./methods/click";
-import "./methods/data";
-import "./methods/find";
-import "./methods/get";
-import "./methods/first";
-import "./methods/html";
-import "./methods/is";
-import "./methods/last";
-import "./methods/unique";
-import "./methods/map";
-import "./methods/submit";
-import "./methods/text";
-import "./methods/toArray";
-import "./methods/trigger";
-import "./methods/type";
-import "./methods/children";
-import "./methods/closest";
+import './methods/attr'
+import './methods/click'
+import './methods/data'
+import './methods/find'
+import './methods/get'
+import './methods/first'
+import './methods/html'
+import './methods/is'
+import './methods/last'
+import './methods/unique'
+import './methods/map'
+import './methods/submit'
+import './methods/text'
+import './methods/toArray'
+import './methods/trigger'
+import './methods/type'
+import './methods/children'
+import './methods/closest'
 
-export { default as until } from "./helpers/until";
+export { default as until } from './helpers/until'
 
 // Export the whole thing
-export default $;
+export default $

--- a/src/jest-matchers/index.js
+++ b/src/jest-matchers/index.js
@@ -1,12 +1,11 @@
-import toBeEnabled from './toBeEnabled';
-import toHaveAttribute from './toHaveAttribute';
-import toHaveClass from './toHaveClass';
-import toHaveHtml from './toHaveHtml';
-import toHaveText from './toHaveText';
-import toHaveValue from './toHaveValue';
-import toMatchSelector from './toMatchSelector';
-import toHaveStyle from './toHaveStyle';
-
+import toBeEnabled from './toBeEnabled'
+import toHaveAttribute from './toHaveAttribute'
+import toHaveClass from './toHaveClass'
+import toHaveHtml from './toHaveHtml'
+import toHaveText from './toHaveText'
+import toHaveValue from './toHaveValue'
+import toMatchSelector from './toMatchSelector'
+import toHaveStyle from './toHaveStyle'
 
 expect.extend({
   toBeEnabled,
@@ -17,4 +16,4 @@ expect.extend({
   toHaveValue,
   toMatchSelector,
   toHaveStyle
-});
+})

--- a/src/jest-matchers/toBeEnabled/index.js
+++ b/src/jest-matchers/toBeEnabled/index.js
@@ -1,36 +1,36 @@
-import { normalize, getPlainTag } from "../../helpers";
+import { normalize, getPlainTag } from '../../helpers'
 
-export default function(frag) {
+export default function (frag) {
   // To avoid double negations ¯\_(ツ)_/¯
-  this.affirmative = !this.isNot;
+  this.affirmative = !this.isNot
 
   // Convert it into a plain array of nodes
-  frag = normalize(frag);
+  frag = normalize(frag)
 
-  for (let el of frag) {
+  for (const el of frag) {
     // Prepare the message if there's an error. It needs to build this string:
     // <input disabled="">
-    const base = getPlainTag(el);
+    const base = getPlainTag(el)
 
     // Boolean indicating if any of the received nodes have the attribute "disabled"
-    const isEnabled = !el.disabled;
+    const isEnabled = !el.disabled
 
     // expect(<input />).toBeEnabled();
     if (this.affirmative) {
       if (!isEnabled) {
-        const msg = `Expected ${base} not to include the attribute "disabled"`;
-        return { pass: false, message: () => msg };
+        const msg = `Expected ${base} not to include the attribute "disabled"`
+        return { pass: false, message: () => msg }
       }
     }
 
     // expect(<input type="text" disabled />).not.toBeEnabled();
     if (this.isNot) {
-        if (isEnabled) {
-        const msg = `Expected ${base} to include the attribute "disabled"`;
-        return { pass: true, message: () => msg };
+      if (isEnabled) {
+        const msg = `Expected ${base} to include the attribute "disabled"`
+        return { pass: true, message: () => msg }
       }
     }
   }
 
-  return { pass: !this.isNot };
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toBeEnabled/test.js
+++ b/src/jest-matchers/toBeEnabled/test.js
@@ -1,97 +1,97 @@
-import React from "react";
-import $ from "../../";
-import "../index.js";
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
 // The base elements that we will use to test
-const $enabled = $(<input />);
-const $disabled = $(<input disabled/>);
+const $enabled = $(<input />)
+const $disabled = $(<input disabled />)
 
-describe(".toBeEnabled()", () => {
-  it("works for a simple case", () => {
-    expect(<input />).toBeEnabled();
-    expect(<input disabled/>).not.toBeEnabled();
-    expect($enabled.get(0)).toBeEnabled();
-    expect($disabled.get(0)).not.toBeEnabled();
-    expect($enabled).toBeEnabled();
-    expect($disabled).not.toBeEnabled();
-  });
+describe('.toBeEnabled()', () => {
+  it('works for a simple case', () => {
+    expect(<input />).toBeEnabled()
+    expect(<input disabled />).not.toBeEnabled()
+    expect($enabled.get(0)).toBeEnabled()
+    expect($disabled.get(0)).not.toBeEnabled()
+    expect($enabled).toBeEnabled()
+    expect($disabled).not.toBeEnabled()
+  })
 
-  it("requires an HTML element", () => {
+  it('requires an HTML element', () => {
     expect(() => expect(null).toBeEnabled()).toThrow(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
+      'expect() should receive an HTMLElement or React Test instance'
+    )
 
-    expect(() => expect("abc").toBeEnabled()).toThrow(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
-  });
+    expect(() => expect('abc').toBeEnabled()).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+  })
 
-  it("requires a valid instance", () => {
+  it('requires a valid instance', () => {
     expect(() => expect(true).toBeEnabled()).toThrow(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
-  });
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+  })
 
   it("fails if it's enabled when we expect it not to", () => {
     expect(() => expect($enabled).not.toBeEnabled()).toThrow(
       'Expected <input> to include the attribute "disabled"'
-    );
-  });
+    )
+  })
 
   it("doesn't fail if it's enabled when we expect it to", () => {
-    expect(() => expect($enabled).toBeEnabled()).not.toThrow();
-  });
+    expect(() => expect($enabled).toBeEnabled()).not.toThrow()
+  })
 
   it("fails if it's disabled when we expect it not to", () => {
     expect(() => expect($disabled).toBeEnabled()).toThrow(
       'Expected <input disabled=""> not to include the attribute "disabled"'
-    );
-  });
+    )
+  })
 
   it("doesn't fail if it's disabled when we expect it to", () => {
-    expect(() => expect($disabled).not.toBeEnabled()).not.toThrow();
-  });
+    expect(() => expect($disabled).not.toBeEnabled()).not.toThrow()
+  })
 
-  describe("multiple elements", () => {
+  describe('multiple elements', () => {
     const $form = $(
       <form>
-        <input id="banana" />
-        <input id="orange" disabled />
+        <input id='banana' />
+        <input id='orange' disabled />
 
-        <textarea id="apple" />
-        <textarea id="pear" />
+        <textarea id='apple' />
+        <textarea id='pear' />
 
-        <button id="mango" disabled />
-        <button id="coconut" disabled />
+        <button id='mango' disabled />
+        <button id='coconut' disabled />
       </form>
-    );
+    )
 
-    it("requires all the specified elements to be enabled", () => {
-      expect($form.find("textarea")).toBeEnabled();
+    it('requires all the specified elements to be enabled', () => {
+      expect($form.find('textarea')).toBeEnabled()
 
-      expect(() => expect($form.find("input")).toBeEnabled()).toThrow(
+      expect(() => expect($form.find('input')).toBeEnabled()).toThrow(
         'Expected <input id="orange" disabled=""> not to include the attribute "disabled"'
-      );
+      )
 
-      expect(() => expect($form.find("input")).not.toBeEnabled()).toThrow(
+      expect(() => expect($form.find('input')).not.toBeEnabled()).toThrow(
         'Expected <input id="banana"> to include the attribute "disabled"'
-      );
+      )
 
-      expect(() => expect($form.find("button")).toBeEnabled()).toThrow(
+      expect(() => expect($form.find('button')).toBeEnabled()).toThrow(
         'Expected <button id="mango" disabled=""> not to include the attribute "disabled"'
-      );
-    });
-    
-    it("requires none of the specified elements to be enabled", () => {
-      expect($form.find("button")).not.toBeEnabled();
+      )
+    })
 
-      expect(() => expect($form.find("textarea")).not.toBeEnabled()).toThrow(
+    it('requires none of the specified elements to be enabled', () => {
+      expect($form.find('button')).not.toBeEnabled()
+
+      expect(() => expect($form.find('textarea')).not.toBeEnabled()).toThrow(
         'Expected <textarea id="apple"> to include the attribute "disabled"'
-      );
+      )
 
-      expect(() => expect($form.find("input")).not.toBeEnabled()).toThrow(
+      expect(() => expect($form.find('input')).not.toBeEnabled()).toThrow(
         'Expected <input id="banana"> to include the attribute "disabled"'
-      );
-    });
-  });
-});
+      )
+    })
+  })
+})

--- a/src/jest-matchers/toHaveAttribute/index.js
+++ b/src/jest-matchers/toHaveAttribute/index.js
@@ -1,39 +1,39 @@
-import { normalize, getPlainTag } from '../../helpers';
+import { normalize, getPlainTag } from '../../helpers'
 
 export default function (frag, attr, val) {
   // To avoid double negations ¯\_(ツ)_/¯
-  this.affirmative = !this.isNot;
+  this.affirmative = !this.isNot
 
   // Convert it into a plain array of nodes
-  frag = normalize(frag);
+  frag = normalize(frag)
 
-  for (let el of frag) {
-    const attributes = [...el.attributes];
-    const base = getPlainTag(el);
+  for (const el of frag) {
+    const attributes = [...el.attributes]
+    const base = getPlainTag(el)
 
     // Find attribute that matches passed in attr and val
     const found = attributes.some(({ name, value }) => {
-      if (attr !== name) return false;
-      if (val instanceof RegExp) return val.test(value);
-      if (typeof val === 'boolean') return value === '';
-      return val ? value === val : true;
-    });
+      if (attr !== name) return false
+      if (val instanceof RegExp) return val.test(value)
+      if (typeof val === 'boolean') return value === ''
+      return val ? value === val : true
+    })
 
     // Prepare val error message
-    let valErrMessage = '';
-    if (val instanceof RegExp) valErrMessage = ` that matches ${val}`;
-    else if (val) valErrMessage = `="${val}"`;
+    let valErrMessage = ''
+    if (val instanceof RegExp) valErrMessage = ` that matches ${val}`
+    else if (val) valErrMessage = `="${val}"`
 
     if (this.affirmative && !found) {
-      const msg = `Expected ${base} to have attribute \`${attr}\`${valErrMessage}`;
-      return { pass: false, message: () => msg };
+      const msg = `Expected ${base} to have attribute \`${attr}\`${valErrMessage}`
+      return { pass: false, message: () => msg }
     }
 
     if (this.isNot && found) {
-      const msg = `Expected ${base} not to have attribute \`${attr}\`${valErrMessage}`;
-      return { pass: true, message: () => msg };
+      const msg = `Expected ${base} not to have attribute \`${attr}\`${valErrMessage}`
+      return { pass: true, message: () => msg }
     }
   }
 
-  return { pass: !this.isNot };
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toHaveAttribute/test.js
+++ b/src/jest-matchers/toHaveAttribute/test.js
@@ -1,121 +1,121 @@
-import React from 'react';
-import $ from '../../';
-import '../index.js';
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
-const $button = $(<button type="submit" />);
-const $input = $(<input type="text" name="name" required />);
+const $button = $(<button type='submit' />)
+const $input = $(<input type='text' name='name' required />)
 
 describe('.toHaveAttribute()', () => {
   it('works for a simple case', () => {
-    expect($button).toHaveAttribute('type', 'submit');
-    expect($input).toHaveAttribute('type', 'text');
-    expect($input).toHaveAttribute('name', 'name');
-    expect($input).toHaveAttribute('required', true);
-    expect($input).toHaveAttribute('required');
-  });
+    expect($button).toHaveAttribute('type', 'submit')
+    expect($input).toHaveAttribute('type', 'text')
+    expect($input).toHaveAttribute('name', 'name')
+    expect($input).toHaveAttribute('required', true)
+    expect($input).toHaveAttribute('required')
+  })
 
   it('requires an HTMLelement', () => {
-    const msg = 'expect() should receive an HTMLElement or React Test instance';
-    expect(() => expect(null).toHaveAttribute('kiwi')).toThrow(msg);
-    expect(() => expect('random').toHaveAttribute('kiwi')).toThrow(msg);
-  });
+    const msg = 'expect() should receive an HTMLElement or React Test instance'
+    expect(() => expect(null).toHaveAttribute('kiwi')).toThrow(msg)
+    expect(() => expect('random').toHaveAttribute('kiwi')).toThrow(msg)
+  })
 
   it('requires a valid instance', () => {
     expect(() => expect({}).toHaveAttribute('kiwi')).toThrow(
       'expect() should receive an HTMLElement or React Test instance'
-    );
-  });
+    )
+  })
 
   it('requires the correct attr name', () => {
     expect(() => expect($button).toHaveAttribute('error')).toThrow(
       'Expected <button type="submit"> to have attribute `error`'
-    );
-  });
+    )
+  })
 
   it('requires the correct attr value', () => {
     expect(() => expect($button).toHaveAttribute('type', 'reset')).toThrow(
       'Expected <button type="submit"> to have attribute `type`="reset"'
-    );
-  });
+    )
+  })
 
   it('fails if attr is found when not expected', () => {
     expect(() => expect($button).not.toHaveAttribute('type')).toThrow(
       'Expected <button type="submit"> not to have attribute `type`'
-    );
-  });
+    )
+  })
 
   it('fails if attr with correct value is found when not expected', () => {
     expect(() => expect($button).not.toHaveAttribute('type', 'submit')).toThrow(
       'Expected <button type="submit"> not to have attribute `type`="submit"'
-    );
-  });
+    )
+  })
 
   describe('regex', () => {
     it('handles regex for values', () => {
-      expect($input).toHaveAttribute('type', /text/);
-      expect($input).toHaveAttribute('type', /te.+/);
-      expect($input).toHaveAttribute('type', /.*/);
-    });
+      expect($input).toHaveAttribute('type', /text/)
+      expect($input).toHaveAttribute('type', /te.+/)
+      expect($input).toHaveAttribute('type', /.*/)
+    })
 
     it('fails when regex is invalid', () => {
       expect(() => expect($input).toHaveAttribute('type', /texax./)).toThrow(
         'Expected <input type="text" name="name" required=""> to have attribute `type` that matches /texax./'
-      );
-    });
+      )
+    })
 
     it('handles negated regex values', () => {
-      expect($input).not.toHaveAttribute('type', /texax./);
-    });
+      expect($input).not.toHaveAttribute('type', /texax./)
+    })
 
     it('fails when negated regex values exist', () => {
       expect(() => expect($input).not.toHaveAttribute('type', /tex.+/)).toThrow(
         'Expected <input type="text" name="name" required=""> not to have attribute `type` that matches /tex.+/'
-      );
-    });
-  });
+      )
+    })
+  })
 
   describe('multiple elements', () => {
     const $list = $(
       <ul>
-        <li id="first" value="1" title="list-item">
+        <li id='first' value='1' title='list-item'>
           apple
         </li>
-        <li value="2" title="list-item">
+        <li value='2' title='list-item'>
           apple
         </li>
       </ul>
-    );
+    )
 
     it('requires all elements to have the same attribute', () => {
-      expect($list.find('li')).toHaveAttribute('value');
+      expect($list.find('li')).toHaveAttribute('value')
       expect(() => expect($list.find('li')).toHaveAttribute('id')).toThrow(
         'Expected <li value="2" title="list-item"> to have attribute `id`'
-      );
-    });
+      )
+    })
 
     it('requires all elements to have the same attribute && value', () => {
       expect(() =>
         expect($list.find('li')).toHaveAttribute('value', '1')
       ).toThrow(
         'Expected <li value="2" title="list-item"> to have attribute `value`="1"'
-      );
-    });
+      )
+    })
 
     it('requires all elements to not have the same attribute', () => {
-      expect($list.find('li')).not.toHaveAttribute('hi');
+      expect($list.find('li')).not.toHaveAttribute('hi')
       expect(() => expect($list.find('li')).not.toHaveAttribute('id')).toThrow(
         'Expected <li id="first" value="1" title="list-item"> not to have attribute `id`'
-      );
-    });
+      )
+    })
 
     it('requires all elements to not have the same attribute && value', () => {
-      expect($list.find('li')).not.toHaveAttribute('title', 'order');
+      expect($list.find('li')).not.toHaveAttribute('title', 'order')
       // Returns the first unmatched element
       expect(() =>
         expect($list.find('li')).not.toHaveAttribute('title', 'list-item')
       ).toThrow(
         'Expected <li id="first" value="1" title="list-item"> not to have attribute `title`="list-item"'
-      );
-    });
-  });
-});
+      )
+    })
+  })
+})

--- a/src/jest-matchers/toHaveClass/index.js
+++ b/src/jest-matchers/toHaveClass/index.js
@@ -1,47 +1,47 @@
-import { normalize, getPlainTag } from "../../helpers";
+import { normalize, getPlainTag } from '../../helpers'
 
 const toStr = list => {
-  return `class${list.length > 1 ? "es" : ""} "${list.join('", "')}"`;
-};
+  return `class${list.length > 1 ? 'es' : ''} "${list.join('", "')}"`
+}
 
-export default function(frag, ...expectedClasses) {
+export default function (frag, ...expectedClasses) {
   // To avoid double negations ¯\_(ツ)_/¯
-  this.affirmative = !this.isNot;
+  this.affirmative = !this.isNot
 
   // Convert it into a plain array of nodes
-  frag = normalize(frag);
+  frag = normalize(frag)
 
   // All of the expected classes
-  const expected = expectedClasses.flat();
+  const expected = expectedClasses.flat()
 
-  for (let el of frag) {
+  for (const el of frag) {
     // Prepare the message if there's an error. It needs to build this string:
     // <button class="primary button">
-    const received = [...el.classList];
-    const base = getPlainTag(el);
+    const received = [...el.classList]
+    const base = getPlainTag(el)
 
     // All the expected classes that have been received
-    const found = expected.filter(name => received.includes(name));
+    const found = expected.filter(name => received.includes(name))
 
     // All of the expected classes that have NOT been received
-    const notfound = expected.filter(name => !received.includes(name));
+    const notfound = expected.filter(name => !received.includes(name))
 
     // expect(<div className="banana" />).toHaveClass('banana');
     if (this.affirmative) {
       if (found.length < expected.length) {
-        const msg = `Expected ${base} to include ${toStr(notfound)}`;
-        return { pass: false, message: () => msg };
+        const msg = `Expected ${base} to include ${toStr(notfound)}`
+        return { pass: false, message: () => msg }
       }
     }
 
     // expect(<div className="orange" />).not.toHaveClass('banana');
     if (this.isNot) {
       if (found.length) {
-        const msg = `Expected ${base} not to include ${toStr(found)}`;
-        return { pass: true, message: () => msg };
+        const msg = `Expected ${base} not to include ${toStr(found)}`
+        return { pass: true, message: () => msg }
       }
     }
   }
 
-  return { pass: !this.isNot };
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toHaveClass/test.js
+++ b/src/jest-matchers/toHaveClass/test.js
@@ -1,108 +1,108 @@
-import React from "react";
-import $ from "../../";
-import "../index.js";
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
 // The base element that we will use to test
-const $div = $(<div className="hello world" />);
+const $div = $(<div className='hello world' />)
 
-describe(".toHaveClass()", () => {
-  it("works for a simple case", () => {
-    expect(<div className="hello world" />).toHaveClass("hello");
-    expect(<div className="hello world" />).not.toHaveClass("banana");
-    expect($div.get(0)).toHaveClass("hello");
-    expect($div.get(0)).not.toHaveClass("banana");
-    expect($div).toHaveClass("hello");
-    expect($div).not.toHaveClass("banana");
-  });
+describe('.toHaveClass()', () => {
+  it('works for a simple case', () => {
+    expect(<div className='hello world' />).toHaveClass('hello')
+    expect(<div className='hello world' />).not.toHaveClass('banana')
+    expect($div.get(0)).toHaveClass('hello')
+    expect($div.get(0)).not.toHaveClass('banana')
+    expect($div).toHaveClass('hello')
+    expect($div).not.toHaveClass('banana')
+  })
 
-  it("requires an HTML element", () => {
-    expect(() => expect(null).toHaveClass("banana")).toThrow(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
+  it('requires an HTML element', () => {
+    expect(() => expect(null).toHaveClass('banana')).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
 
-    expect(() => expect("abc").toHaveClass("banana")).toThrow(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
-  });
+    expect(() => expect('abc').toHaveClass('banana')).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+  })
 
-  it("requires a valid instance", () => {
-    expect(() => expect(true).toHaveClass("banana")).toThrow(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
-  });
+  it('requires a valid instance', () => {
+    expect(() => expect(true).toHaveClass('banana')).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+  })
 
   it("requires a class if it's not found", () => {
-    expect(() => expect($div).toHaveClass("banana")).toThrow(
+    expect(() => expect($div).toHaveClass('banana')).toThrow(
       'Expected <div class="hello world"> to include class "banana"'
-    );
-  });
+    )
+  })
 
-  it("only requires the class that is not found", () => {
-    expect(() => expect($div).toHaveClass("hello", "banana")).toThrow(
+  it('only requires the class that is not found', () => {
+    expect(() => expect($div).toHaveClass('hello', 'banana')).toThrow(
       'Expected <div class="hello world"> to include class "banana"'
-    );
-  });
+    )
+  })
 
-  it("can pluralize class names", () => {
-    expect(() => expect($div).toHaveClass("potato", "banana")).toThrow(
+  it('can pluralize class names', () => {
+    expect(() => expect($div).toHaveClass('potato', 'banana')).toThrow(
       'Expected <div class="hello world"> to include classes "potato", "banana"'
-    );
-  });
+    )
+  })
 
   it("fails if it's found when not expected", () => {
-    expect(() => expect($div).not.toHaveClass("hello")).toThrow(
+    expect(() => expect($div).not.toHaveClass('hello')).toThrow(
       'Expected <div class="hello world"> not to include class "hello"'
-    );
-  });
+    )
+  })
 
-  it("only fails with the class that is found", () => {
+  it('only fails with the class that is found', () => {
     expect(() => {
-      expect($div).not.toHaveClass("hello", "banana");
+      expect($div).not.toHaveClass('hello', 'banana')
     }).toThrow(
       'Expected <div class="hello world"> not to include class "hello"'
-    );
-  });
+    )
+  })
 
   it("pluralizes if there's multiple fails", () => {
     expect(() => {
-      expect($div).not.toHaveClass("hello", "world");
+      expect($div).not.toHaveClass('hello', 'world')
     }).toThrow(
       'Expected <div class="hello world"> not to include classes "hello", "world"'
-    );
-  });
+    )
+  })
 
-  describe("multiple elements", () => {
+  describe('multiple elements', () => {
     const $list = $(
       <ul>
-        <li className="item main">a</li>
-        <li className="item secondary">b</li>
+        <li className='item main'>a</li>
+        <li className='item secondary'>b</li>
       </ul>
-    );
+    )
 
-    it("requires all the elements to have the class", () => {
-      expect($list.find("li")).toHaveClass("item");
+    it('requires all the elements to have the class', () => {
+      expect($list.find('li')).toHaveClass('item')
 
-      expect(() => expect($list.find("li")).toHaveClass("main")).toThrow(
+      expect(() => expect($list.find('li')).toHaveClass('main')).toThrow(
         'Expected <li class="item secondary"> to include class "main"'
-      );
-    });
+      )
+    })
 
-    it("requires no element to have the class", () => {
-      expect($list.find("li")).not.toHaveClass("demo");
+    it('requires no element to have the class', () => {
+      expect($list.find('li')).not.toHaveClass('demo')
 
-      expect(() => expect($list.find("li")).not.toHaveClass("item")).toThrow(
+      expect(() => expect($list.find('li')).not.toHaveClass('item')).toThrow(
         'Expected <li class="item main"> not to include class "item"'
-      );
+      )
 
-      expect(() => expect($list.find("li")).not.toHaveClass("main")).toThrow(
+      expect(() => expect($list.find('li')).not.toHaveClass('main')).toThrow(
         'Expected <li class="item main"> not to include class "main"'
-      );
+      )
 
       expect(() =>
-        expect($list.find("li")).not.toHaveClass("secondary")
+        expect($list.find('li')).not.toHaveClass('secondary')
       ).toThrow(
         'Expected <li class="item secondary"> not to include class "secondary"'
-      );
-    });
-  });
-});
+      )
+    })
+  })
+})

--- a/src/jest-matchers/toHaveHtml/index.js
+++ b/src/jest-matchers/toHaveHtml/index.js
@@ -1,23 +1,23 @@
-import { normalize, getPlainTag } from '../../helpers';
+import { normalize, getPlainTag } from '../../helpers'
 
 export default function (frag, html) {
-  this.affirmative = !this.isNot;
-  frag = normalize(frag);
+  this.affirmative = !this.isNot
+  frag = normalize(frag)
 
-  for (let el of frag) {
-    const base = getPlainTag(el);
-    const hasHTML = el.outerHTML.includes(html.trim());
+  for (const el of frag) {
+    const base = getPlainTag(el)
+    const hasHTML = el.outerHTML.includes(html.trim())
 
     if (this.affirmative && !hasHTML) {
-      const msg = `Expected ${base} to have \`${html}\``;
-      return { pass: false, message: () => msg };
+      const msg = `Expected ${base} to have \`${html}\``
+      return { pass: false, message: () => msg }
     }
 
     if (this.isNot && hasHTML) {
-      const msg = `Expected ${base} not to have \`${html}\``;
-      return { pass: true, message: () => msg };
+      const msg = `Expected ${base} not to have \`${html}\``
+      return { pass: true, message: () => msg }
     }
   }
 
-  return { pass: !this.isNot };
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toHaveHtml/test.js
+++ b/src/jest-matchers/toHaveHtml/test.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import $ from '../../';
-import '../index.js';
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
 const $div = $(
   <div>
@@ -10,78 +10,78 @@ const $div = $(
       <b>here</b>
     </span>
   </div>
-);
+)
 
 describe('.toHaveHtml()', () => {
   it('works for a simple case', () => {
-    expect($div).toHaveHtml('<span>I am a span</span>');
-  });
+    expect($div).toHaveHtml('<span>I am a span</span>')
+  })
 
   it('requires valid html', () => {
     expect(() => expect($div).toHaveHtml('<h1>header</h1>')).toThrow(
       'Expected <div> to have `<h1>header</h1>`'
-    );
-  });
+    )
+  })
 
   it('validates all children of innerHTML', () => {
-    expect($div).toHaveHtml('<span>I am a span</span>');
-    expect($div).toHaveHtml('<span>Im also here</span>');
-    expect($div).toHaveHtml('Im also here');
-    expect($div).toHaveHtml('<b>here</b>');
-  });
+    expect($div).toHaveHtml('<span>I am a span</span>')
+    expect($div).toHaveHtml('<span>Im also here</span>')
+    expect($div).toHaveHtml('Im also here')
+    expect($div).toHaveHtml('<b>here</b>')
+  })
 
   it('trims passed HTML to check', () => {
-    expect($div).toHaveHtml('     <span>I am a span</span>');
-    expect($div).toHaveHtml('<span>Im also here</span>     ');
-    expect($div).toHaveHtml('Im also here    ');
-  });
+    expect($div).toHaveHtml('     <span>I am a span</span>')
+    expect($div).toHaveHtml('<span>Im also here</span>     ')
+    expect($div).toHaveHtml('Im also here    ')
+  })
 
   it('negatively asserts non-existent HTML', () => {
-    expect($div).not.toHaveHtml('<h1>header</h1>');
+    expect($div).not.toHaveHtml('<h1>header</h1>')
     expect(() =>
       expect($div).not.toHaveHtml('<span>I am a span</span>')
-    ).toThrow('Expected <div> not to have `<span>I am a span</span>`');
-  });
+    ).toThrow('Expected <div> not to have `<span>I am a span</span>`')
+  })
 
   describe('multiple elements', () => {
     const $divs = $(
       <section>
-        <div id="div-1">
+        <div id='div-1'>
           <span>span text</span>
         </div>
-        <div id="div-2">
+        <div id='div-2'>
           <span>span text</span>
         </div>
       </section>
-    ).find('div');
+    ).find('div')
 
-    const validInnerHTMLs = ['<span>span text</span>', 'span text'];
-    const invalidInnerHTMLs = ['<p></p>', '<li></li>', '<span>div</span>'];
+    const validInnerHTMLs = ['<span>span text</span>', 'span text']
+    const invalidInnerHTMLs = ['<p></p>', '<li></li>', '<span>div</span>']
 
     it('requires all elements to contain html', () => {
       for (const validHTML of validInnerHTMLs) {
-        expect($divs).toHaveHtml(validHTML);
+        expect($divs).toHaveHtml(validHTML)
       }
 
       // Throws on first child with non-existent HTML
       for (const invalidHTML of invalidInnerHTMLs) {
         expect(() => expect($divs).toHaveHtml(invalidHTML)).toThrow(
           `Expected <div id="div-1"> to have \`${invalidHTML}\``
-        );
+        )
       }
-    });
+    })
 
     it('negatively asserts multiple elements', () => {
       for (const invalidHTML of invalidInnerHTMLs) {
-        expect($divs).not.toHaveHtml(invalidHTML);
+        expect($divs).not.toHaveHtml(invalidHTML)
       }
 
       // Throws on first child with valid HTML
       for (const validHTML of validInnerHTMLs) {
         expect(() => expect($divs).not.toHaveHtml(validHTML)).toThrow(
           `Expected <div id="div-1"> not to have \`${validHTML}\``
-        );
+        )
       }
-    });
-  });
-});
+    })
+  })
+})

--- a/src/jest-matchers/toHaveStyle/index.js
+++ b/src/jest-matchers/toHaveStyle/index.js
@@ -1,66 +1,63 @@
-import { normalize, getPlainTag } from "../../helpers";
+import { normalize, getPlainTag } from '../../helpers'
 
 // Parse JS camelCase style properties to lowercase hyphenated strings
 const parseCamelCase = (styleToParse) => styleToParse
-    .replace(/([a-z\d])([A-Z])/g, '$1' + "-" + '$2')
-    .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1' + "-" + '$2')
-    .toLowerCase();
+  .replace(/([a-z\d])([A-Z])/g, '$1' + '-' + '$2')
+  .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1' + '-' + '$2')
+  .toLowerCase()
 
 // Clean styles object to return string array of individual styles styles
-const cleanStylesObject = (styles) => Object.entries(styles).map(([key, value]) => `${parseCamelCase(key)}: ${value}`);
+const cleanStylesObject = (styles) => Object.entries(styles).map(([key, value]) => `${parseCamelCase(key)}: ${value}`)
 
 // Split style string into array with all semicolons and spaces removed
 const cleanStylesStr = (stylesStr) => {
-    let styles = stylesStr.split("; ");
-    styles[styles.length - 1] = styles[styles.length - 1].replace(/;/g, "");
-    return styles;
+  const styles = stylesStr.split('; ')
+  styles[styles.length - 1] = styles[styles.length - 1].replace(/;/g, '')
+  return styles
 }
 
 // Get correct error msg string depending on number of incorrect styles
-const getErrorStr = incorrectStyles => `style${incorrectStyles.length > 1 ? "s" : ""} [${incorrectStyles.join(", ")}]`;
+const getErrorStr = incorrectStyles => `style${incorrectStyles.length > 1 ? 's' : ''} [${incorrectStyles.join(', ')}]`
 
 export default function (frag, styles) {
-    // To avoid double negations ¯\_(ツ)_/¯
-    this.affirmative = !this.isNot;
+  // To avoid double negations ¯\_(ツ)_/¯
+  this.affirmative = !this.isNot
 
-    // Convert it into a plain array of nodes
-    frag = normalize(frag);
+  // Convert it into a plain array of nodes
+  frag = normalize(frag)
 
-    for (let el of frag) {
+  for (const el of frag) {
+    // Get the element string for use in error message if test fails
+    const base = getPlainTag(el)
 
-        // Get the element string for use in error message if test fails
-        const base = getPlainTag(el);
+    // Get an array of style strings present on the HTML element
+    const elStyles = Object.entries(el.style._values).map(([key, value]) => `${key}: ${value}`)
 
-        // Get an array of style strings present on the HTML element
-        const elStyles = Object.entries(el.style["_values"]).map(([key, value]) => `${key}: ${value}`);
+    // Get an array of style strings to search for in the element styles. Has to handle styles argument of either type string or type object
+    const stylesArray = typeof styles === 'string' ? cleanStylesStr(styles) : cleanStylesObject(styles)
 
-        // Get an array of style strings to search for in the element styles. Has to handle styles argument of either type string or type object
-        let stylesArray = typeof styles === "string" ? cleanStylesStr(styles) : cleanStylesObject(styles);
+    // expect(<div style={{display: "none"}} />).toHaveStyle({ display: "none" });
+    if (this.affirmative) {
+      // Check each of the search styles to see if they're present on the HTML element and isolate missing styles
+      const missingStyles = stylesArray.filter(styleToBeChecked => !elStyles.includes(styleToBeChecked))
 
-        // expect(<div style={{display: "none"}} />).toHaveStyle({ display: "none" });
-        if (this.affirmative) {
-
-            // Check each of the search styles to see if they're present on the HTML element and isolate missing styles
-            const missingStyles = stylesArray.filter(styleToBeChecked => !elStyles.includes(styleToBeChecked));
-
-            if (missingStyles.length) {
-                const msg = `Expected ${base} to include ${getErrorStr(missingStyles)}`;
-                return { pass: false, message: () => msg };
-            }
-        }
-
-        // expect(<div style={{display: "none"}} />).not.toHaveStyle({ backgroundColor: "red" });
-        if (this.isNot) {
-
-            // Check each of the search styles to see if they're incorrectly present on the HTML element and isolate those that are
-            const incorrectStyles = stylesArray.filter(styleToBeChecked => elStyles.includes(styleToBeChecked));
-
-            if (incorrectStyles.length) {
-                const msg = `Expected ${base} not to include ${getErrorStr(incorrectStyles)}`;
-                return { pass: true, message: () => msg };
-            }
-        }
+      if (missingStyles.length) {
+        const msg = `Expected ${base} to include ${getErrorStr(missingStyles)}`
+        return { pass: false, message: () => msg }
+      }
     }
 
-    return { pass: !this.isNot };
+    // expect(<div style={{display: "none"}} />).not.toHaveStyle({ backgroundColor: "red" });
+    if (this.isNot) {
+      // Check each of the search styles to see if they're incorrectly present on the HTML element and isolate those that are
+      const incorrectStyles = stylesArray.filter(styleToBeChecked => elStyles.includes(styleToBeChecked))
+
+      if (incorrectStyles.length) {
+        const msg = `Expected ${base} not to include ${getErrorStr(incorrectStyles)}`
+        return { pass: true, message: () => msg }
+      }
+    }
+  }
+
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toHaveStyle/test.js
+++ b/src/jest-matchers/toHaveStyle/test.js
@@ -1,127 +1,125 @@
-import React from "react";
-import $ from "../../";
-import "../index.js";
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
 // The base style object to test against
-const styleObj = { display: "none", textAlign: "center" };
-const styleStr = "text-align: center; display: none;";
+const styleObj = { display: 'none', textAlign: 'center' }
+const styleStr = 'text-align: center; display: none;'
 
 // The base element that we will use to test
-const $div = $(<div style={styleObj} />);
+const $div = $(<div style={styleObj} />)
 
-describe(".toHaveStyle()", () => {
+describe('.toHaveStyle()', () => {
+  it('requires an HTML element', () => {
+    expect(() => expect(null).toHaveStyle(styleObj)).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+    expect(() => expect('abc').toHaveStyle(styleObj)).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+  })
 
-    it("requires an HTML element", () => {
-        expect(() => expect(null).toHaveStyle(styleObj)).toThrow(
-            "expect() should receive an HTMLElement or React Test instance"
-        );
-        expect(() => expect("abc").toHaveStyle(styleObj)).toThrow(
-            "expect() should receive an HTMLElement or React Test instance"
-        );
-    });
+  it('requires a valid instance', () => {
+    expect(() => expect(true).toHaveStyle(styleObj)).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+  })
 
-    it("requires a valid instance", () => {
-        expect(() => expect(true).toHaveStyle(styleObj)).toThrow(
-            "expect() should receive an HTMLElement or React Test instance"
-        );
-    });
+  it('works for a simple case', () => {
+    expect(<div style={styleObj} />).toHaveStyle(styleObj)
+    expect($div).toHaveStyle(styleObj)
+  })
 
-    it("works for a simple case", () => {
-        expect(<div style={styleObj} />).toHaveStyle(styleObj);
-        expect($div).toHaveStyle(styleObj);
-    });
+  it('can search for individual styles', () => {
+    expect($div).toHaveStyle({ display: 'none' })
+    expect($div).toHaveStyle('text-align: center')
+  })
 
-    it("can search for individual styles", () => {
-        expect($div).toHaveStyle({ display: "none" });
-        expect($div).toHaveStyle("text-align: center")
-    });
+  it('can search for multiple styles', () => {
+    expect($div).toHaveStyle(styleObj)
+    expect($div).toHaveStyle('display: none; text-align: center')
+  })
 
-    it("can search for multiple styles", () => {
-        expect($div).toHaveStyle(styleObj);
-        expect($div).toHaveStyle("display: none; text-align: center")
-    });
+  it('can handle negative cases', () => {
+    expect($div).not.toHaveStyle({ backgroundColor: 'red' })
+    expect($div).not.toHaveStyle({ width: '100px' })
+  })
 
-    it("can handle negative cases", () => {
-        expect($div).not.toHaveStyle({ backgroundColor: "red" });
-        expect($div).not.toHaveStyle({ width: "100px" });
-    });
+  it('can handle styles argument of either type string or object', () => {
+    expect($div).toHaveStyle(styleObj)
+    expect($div).toHaveStyle(styleStr)
+    expect($div).not.toHaveStyle({ textAlign: 'left' })
+  })
 
-    it("can handle styles argument of either type string or object", () => {
-        expect($div).toHaveStyle(styleObj);
-        expect($div).toHaveStyle(styleStr);
-        expect($div).not.toHaveStyle({ textAlign: "left" });
-    });
+  it('can handle styles string argument with or without final semicolon', () => {
+    expect($div).toHaveStyle('text-align: center; display: none;')
+    expect($div).toHaveStyle('text-align: center; display: none')
+  })
 
-    it("can handle styles string argument with or without final semicolon", () => {
-        expect($div).toHaveStyle("text-align: center; display: none;");
-        expect($div).toHaveStyle("text-align: center; display: none");
-    });
+  it('throws the correct error message when a single style is missing', () => {
+    expect(() => expect($div).toHaveStyle({ color: 'purple' }))
+      .toThrow('Expected <div style="display: none; text-align: center;"> to include style [color: purple]')
+    expect(() => expect($div).toHaveStyle({ width: '200px' }))
+      .toThrow('Expected <div style="display: none; text-align: center;"> to include style [width: 200px]')
+    expect(() => expect($div).toHaveStyle('width: 200px'))
+      .toThrow('Expected <div style="display: none; text-align: center;"> to include style [width: 200px]')
+  })
 
-    it("throws the correct error message when a single style is missing", () => {
-        expect(() => expect($div).toHaveStyle({ color: 'purple' }))
-            .toThrow('Expected <div style="display: none; text-align: center;"> to include style [color: purple]');
-        expect(() => expect($div).toHaveStyle({ width: '200px' }))
-            .toThrow('Expected <div style="display: none; text-align: center;"> to include style [width: 200px]');
-        expect(() => expect($div).toHaveStyle('width: 200px'))
-            .toThrow('Expected <div style="display: none; text-align: center;"> to include style [width: 200px]');
-    });
+  it('throws the correct error message when multiple styles are missing', () => {
+    expect(() => expect($div).toHaveStyle({ color: 'purple', width: '200px' }))
+      .toThrow('Expected <div style="display: none; text-align: center;"> to include styles [color: purple, width: 200px]')
+    expect(() => expect($div).toHaveStyle('text-align: center; color: purple; width: 200px'))
+      .toThrow('Expected <div style="display: none; text-align: center;"> to include styles [color: purple, width: 200px]')
+  })
 
-    it("throws the correct error message when multiple styles are missing", () => {
-        expect(() => expect($div).toHaveStyle({ color: 'purple', width: '200px' }))
-            .toThrow('Expected <div style="display: none; text-align: center;"> to include styles [color: purple, width: 200px]');
-        expect(() => expect($div).toHaveStyle('text-align: center; color: purple; width: 200px'))
-            .toThrow('Expected <div style="display: none; text-align: center;"> to include styles [color: purple, width: 200px]');
-    });
+  it('throws the correct error message when a single style is incorrectly present', () => {
+    expect(() => expect($div).not.toHaveStyle({ display: 'none' }))
+      .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [display: none]')
+    expect(() => expect($div).not.toHaveStyle('text-align: center'))
+      .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [text-align: center]')
+    expect(() => expect($div).not.toHaveStyle('text-align: center;'))
+      .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [text-align: center]')
+  })
 
-    it("throws the correct error message when a single style is incorrectly present", () => {
-        expect(() => expect($div).not.toHaveStyle({ display: 'none' }))
-            .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [display: none]');
-        expect(() => expect($div).not.toHaveStyle('text-align: center'))
-            .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [text-align: center]');
-        expect(() => expect($div).not.toHaveStyle('text-align: center;'))
-            .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [text-align: center]');
-    });
-
-    it("throws the correct error message when multiple styles are incorrectly present", () => {
-        expect(() => expect($div).not.toHaveStyle(styleObj))
-            .toThrow('Expected <div style="display: none; text-align: center;"> not to include styles [display: none, text-align: center]');
-        expect(() => expect($div).not.toHaveStyle('display: none; text-align: center'))
-            .toThrow('Expected <div style="display: none; text-align: center;"> not to include styles [display: none, text-align: center]');
-        expect(() => expect($div).not.toHaveStyle('text-align: center; color: red'))
-            .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [text-align: center]');
-    });
-});
+  it('throws the correct error message when multiple styles are incorrectly present', () => {
+    expect(() => expect($div).not.toHaveStyle(styleObj))
+      .toThrow('Expected <div style="display: none; text-align: center;"> not to include styles [display: none, text-align: center]')
+    expect(() => expect($div).not.toHaveStyle('display: none; text-align: center'))
+      .toThrow('Expected <div style="display: none; text-align: center;"> not to include styles [display: none, text-align: center]')
+    expect(() => expect($div).not.toHaveStyle('text-align: center; color: red'))
+      .toThrow('Expected <div style="display: none; text-align: center;"> not to include style [text-align: center]')
+  })
+})
 
 // Base list element to be used in test cases for multiple elements
 const $list = $(
-    <ul>
-        <li style={styleObj}></li>
-        <li style={styleObj}></li>
-        <li style={{ ...styleObj, color: "red" }}></li>
-    </ul>
-);
+  <ul>
+    <li style={styleObj} />
+    <li style={styleObj} />
+    <li style={{ ...styleObj, color: 'red' }} />
+  </ul>
+)
 
-describe(".toHaveStyle() - checkmultiple elements", () => {
+describe('.toHaveStyle() - checkmultiple elements', () => {
+  it('should be able to check styles are present on multiple elements', () => {
+    expect($list.find('li')).toHaveStyle(styleObj)
+    expect($list.find('li')).toHaveStyle('display: none')
+    expect($list.find('li')).toHaveStyle({ textAlign: 'center' })
+  })
 
-    it('should be able to check styles are present on multiple elements', () => {
-        expect($list.find('li')).toHaveStyle(styleObj);
-        expect($list.find('li')).toHaveStyle("display: none");
-        expect($list.find('li')).toHaveStyle({ textAlign: "center" });
-    })
+  it('should be able to check styles are absent multiple elements', () => {
+    expect($list.find('li')).not.toHaveStyle('color: green')
+    expect($list.find('li')).not.toHaveStyle('width: 20px')
+    expect($list.find('li')).not.toHaveStyle({ height: '100%' })
+  })
 
-    it('should be able to check styles are absent multiple elements', () => {
-        expect($list.find('li')).not.toHaveStyle("color: green");
-        expect($list.find('li')).not.toHaveStyle("width: 20px");
-        expect($list.find('li')).not.toHaveStyle({ height: "100%" });
-    })
+  it('should check styles are present on all elements', () => {
+    expect(() => expect($list.find('li')).toHaveStyle('color: red'))
+      .toThrow('Expected <li style="display: none; text-align: center;"> to include style [color: red]')
+  })
 
-    it('should check styles are present on all elements', () => {
-        expect(() => expect($list.find('li')).toHaveStyle("color: red"))
-            .toThrow('Expected <li style="display: none; text-align: center;"> to include style [color: red]')
-    })
-
-    it('should check styles are not present on all elements', () => {
-        expect(() => expect($list.find('li')).not.toHaveStyle("color: red"))
-            .toThrow('Expected <li style="display: none; text-align: center; color: red;"> not to include style [color: red]')
-    })
+  it('should check styles are not present on all elements', () => {
+    expect(() => expect($list.find('li')).not.toHaveStyle('color: red'))
+      .toThrow('Expected <li style="display: none; text-align: center; color: red;"> not to include style [color: red]')
+  })
 })

--- a/src/jest-matchers/toHaveText/index.js
+++ b/src/jest-matchers/toHaveText/index.js
@@ -1,36 +1,34 @@
-import { normalize, getPlainTag } from "../../helpers";
+import { normalize, getPlainTag } from '../../helpers'
 
-const whitespace = str => str.replace(/\s+/g, " ");
+const whitespace = (str) => str.replace(/\s+/g, ' ')
 
-export default function(frag, expected) {
+export default function (frag, expected) {
   // To avoid double negations ¯\_(ツ)_/¯
-  this.affirmative = !this.isNot;
+  this.affirmative = !this.isNot
 
   // Convert it into a plain array of nodes
-  frag = normalize(frag);
+  frag = normalize(frag)
 
-  for (let el of frag) {
+  for (const el of frag) {
     // Prepare the message if there's an error. It needs to build this string:
     // <button class="primary button">
-    const received = el.textContent;
-    const base = getPlainTag(el);
+    const received = el.textContent
+    const base = getPlainTag(el)
 
-    // expect(<div>banana</div>).toHaveText('banana');
     if (this.affirmative) {
+      // expect(<div>banana</div>).toHaveText('banana');
       if (whitespace(received) !== whitespace(expected)) {
-        const msg = `Expected ${base} to have text "${expected}" but it received "${received}"`;
-        return { pass: false, message: () => msg };
+        const msg = `Expected ${base} to have text "${expected}" but it received "${received}"`
+        return { pass: false, message: () => msg }
       }
-    }
-
-    // expect(<div>orange</div>).not.toHaveText('banana');
-    else {
+    } else {
+      // expect(<div>orange</div>).not.toHaveText('banana');
       if (whitespace(received) === whitespace(expected)) {
-        const msg = `Expected ${base} not to have the text "${received}"`;
-        return { pass: true, message: () => msg };
+        const msg = `Expected ${base} not to have the text "${received}"`
+        return { pass: true, message: () => msg }
       }
     }
   }
 
-  return { pass: !this.isNot };
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toHaveText/test.js
+++ b/src/jest-matchers/toHaveText/test.js
@@ -1,40 +1,40 @@
-import React from "react";
-import $ from "../../";
-import "../index.js";
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
-describe(".toHaveText()", () => {
-  it("requires an HTML element", () => {
-    const msg = "expect() should receive an HTMLElement or React Test instance";
-    expect(() => expect(null).toHaveText("banana")).toThrow(msg);
-    expect(() => expect("abc").toHaveText("banana")).toThrow(msg);
-  });
+describe('.toHaveText()', () => {
+  it('requires an HTML element', () => {
+    const msg = 'expect() should receive an HTMLElement or React Test instance'
+    expect(() => expect(null).toHaveText('banana')).toThrow(msg)
+    expect(() => expect('abc').toHaveText('banana')).toThrow(msg)
+  })
 
-  it("works for a simple case", () => {
-    expect(<div>Hello</div>).toHaveText("Hello");
-  });
+  it('works for a simple case', () => {
+    expect(<div>Hello</div>).toHaveText('Hello')
+  })
 
-  it("rejects in the simple case", () => {
-    expect(() => expect(<div>banana</div>).toHaveText("apple")).toThrow(
+  it('rejects in the simple case', () => {
+    expect(() => expect(<div>banana</div>).toHaveText('apple')).toThrow(
       'Expected <div> to have text "apple" but it received "banana"'
-    );
-  });
+    )
+  })
 
-  it("normalizes the whitespace", () => {
+  it('normalizes the whitespace', () => {
     const text = $(
       <div>
         Hello <br /> world!
       </div>
-    );
-    expect(text).toHaveText("Hello world!");
-  });
+    )
+    expect(text).toHaveText('Hello world!')
+  })
 
-  it("can be negated", () => {
-    expect(<div>Hello</div>).not.toHaveText("Hi");
-  });
+  it('can be negated', () => {
+    expect(<div>Hello</div>).not.toHaveText('Hi')
+  })
 
-  it("rejects with the negation", () => {
-    expect(() => expect(<div>banana</div>).not.toHaveText("banana")).toThrow(
+  it('rejects with the negation', () => {
+    expect(() => expect(<div>banana</div>).not.toHaveText('banana')).toThrow(
       'Expected <div> not to have the text "banana"'
-    );
-  });
-});
+    )
+  })
+})

--- a/src/jest-matchers/toHaveValue/index.js
+++ b/src/jest-matchers/toHaveValue/index.js
@@ -1,52 +1,53 @@
-import { normalize, getPlainTag } from '../../helpers';
+import { normalize, getPlainTag } from '../../helpers'
 
 export default function (frag, value) {
   // To avoid double negations ¯\_(ツ)_/¯
-  this.affirmative = !this.isNot;
+  this.affirmative = !this.isNot
 
   // Convert it into a plain array of nodes
-  frag = normalize(frag);
+  frag = normalize(frag)
 
-  //Should only handle one element
-  if (frag.length > 1)
+  // Should only handle one element
+  if (frag.length > 1) {
     throw new Error(
       'Cannot check multiple elements for values. Please pass only one element.'
-    );
+    )
+  }
 
-  const el = frag[0];
+  const el = frag[0]
 
-  const tagName = el.tagName.toLowerCase();
+  const tagName = el.tagName.toLowerCase()
   if (tagName === 'input' && ['checkbox', 'radio'].includes(el.type)) {
     throw new Error(
       'Cannot check .toHaveValue() for input type="checkbox" or type="radio".'
-    );
-  }
+    )
+  } // eslint-disable-line no-use-before-define
 
-  const base = getPlainTag(el);
-  let matches = false;
+  const base = getPlainTag(el)
+  let matches = false
   if (tagName === 'input') {
     matches =
-      el.type === 'number' ? Number(el.value) === value : el.value === value;
+      el.type === 'number' ? Number(el.value) === value : el.value === value
   } else if (tagName === 'textarea') {
-    matches = el.value === value;
+    matches = el.value === value
   } else if (tagName === 'select') {
-    const selected = [...el.options].find((option) => option.selected);
-    matches = selected.value === value;
+    const selected = [...el.options].find((option) => option.selected)
+    matches = selected.value === value
   } else {
     throw new Error(
       'Not a valid element that has a value attribute. Please insert an element that has a value.'
-    );
+    )
   }
 
   if (this.affirmative && !matches) {
-    const msg = `Expected ${base} to have value=${value}`;
-    return { pass: false, message: () => msg };
+    const msg = `Expected ${base} to have value=${value}`
+    return { pass: false, message: () => msg }
   }
 
   if (this.isNot && matches) {
-    const msg = `Expected ${base} not to have value=${value}`;
-    return { pass: true, message: () => msg };
+    const msg = `Expected ${base} not to have value=${value}`
+    return { pass: true, message: () => msg }
   }
 
-  return { pass: !this.isNot };
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toHaveValue/test.js
+++ b/src/jest-matchers/toHaveValue/test.js
@@ -1,117 +1,117 @@
-import React from 'react';
-import $ from '../../';
-import '../index.js';
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
 // Requires readOnly or onChange when value is set
-const $textInput = $(<input type="text" value="text" readOnly />);
-const $numberInput = $(<input type="number" value="10" readOnly />);
-const $textarea = $(<textarea value="text description" readOnly />);
+const $textInput = $(<input type='text' value='text' readOnly />)
+const $numberInput = $(<input type='number' value='10' readOnly />)
+const $textarea = $(<textarea value='text description' readOnly />)
 const $select = $(
-  <select value="second" onChange={() => {}}>
-    <option value="first">first</option>
-    <option value="second">second</option>
-    <option value="third">third</option>
+  <select value='second' onChange={() => {}}>
+    <option value='first'>first</option>
+    <option value='second'>second</option>
+    <option value='third'>third</option>
   </select>
-);
+)
 
 describe('.toHaveValue()', () => {
   it('requires an HTMLelement', () => {
-    const msg = 'expect() should receive an HTMLElement or React Test instance';
-    expect(() => expect(null).toHaveValue('kiwi')).toThrow(msg);
-    expect(() => expect('random').toHaveValue('kiwi')).toThrow(msg);
-  });
+    const msg = 'expect() should receive an HTMLElement or React Test instance'
+    expect(() => expect(null).toHaveValue('kiwi')).toThrow(msg)
+    expect(() => expect('random').toHaveValue('kiwi')).toThrow(msg)
+  })
 
   it('requires a valid instance', () => {
     expect(() => expect({}).toHaveValue('kiwi')).toThrow(
       'expect() should receive an HTMLElement or React Test instance'
-    );
-  });
+    )
+  })
 
   it('works for a simple case', () => {
-    expect($textInput).toHaveValue('text');
-    expect($numberInput).toHaveValue(10);
-    expect($textarea).toHaveValue('text description');
-    expect($select).toHaveValue('second');
-  });
+    expect($textInput).toHaveValue('text')
+    expect($numberInput).toHaveValue(10)
+    expect($textarea).toHaveValue('text description')
+    expect($select).toHaveValue('second')
+  })
 
   it('handles negative assertions', () => {
-    expect($textInput).not.toHaveValue(10);
-    expect($numberInput).not.toHaveValue('text');
-    expect($textarea).not.toHaveValue('random');
-    expect($select).not.toHaveValue('first');
-  });
+    expect($textInput).not.toHaveValue(10)
+    expect($numberInput).not.toHaveValue('text')
+    expect($textarea).not.toHaveValue('random')
+    expect($select).not.toHaveValue('first')
+  })
 
   it('checks defaultValue when set', () => {
-    const $input = $(<input type="text" defaultValue="initial text" />);
-    const $textarea = $(<textarea defaultValue="initial textarea" />);
+    const $input = $(<input type='text' defaultValue='initial text' />)
+    const $textarea = $(<textarea defaultValue='initial textarea' />)
 
-    expect($input).toHaveValue('initial text');
-    expect($textarea).toHaveValue('initial textarea');
-  });
+    expect($input).toHaveValue('initial text')
+    expect($textarea).toHaveValue('initial textarea')
+  })
 
   it('cannot check for values on input types, checkbox and radio', () => {
-    const $checkbox = $(<input type="checkbox" checked readOnly />);
-    const $radio = $(<input type="radio" value="something" checked readOnly />);
+    const $checkbox = $(<input type='checkbox' checked readOnly />)
+    const $radio = $(<input type='radio' value='something' checked readOnly />)
 
     expect(() => expect($checkbox).toHaveValue('check')).toThrow(
       'Cannot check .toHaveValue() for input type="checkbox" or type="radio".'
-    );
+    )
     expect(() => expect($radio).toHaveValue('radio')).toThrow(
       'Cannot check .toHaveValue() for input type="checkbox" or type="radio".'
-    );
-  });
+    )
+  })
 
   it('requires only one element', () => {
     const $list = $(
       <li>
-        <input type="text" value="first" readOnly />
-        <input type="text" value="second" readOnly />
+        <input type='text' value='first' readOnly />
+        <input type='text' value='second' readOnly />
       </li>
-    );
+    )
     expect(() => expect($list.find('input')).toHaveValue('first')).toThrow(
       'Cannot check multiple elements for values. Please pass only one element.'
-    );
-  });
+    )
+  })
 
   it('requires elements that can return values', () => {
-    const $button = $(<button>click</button>);
-    const $link = $(<a href="hello.com">click</a>);
+    const $button = $(<button>click</button>)
+    const $link = $(<a href='hello.com'>click</a>)
 
     expect(() => expect($button).toHaveValue('button')).toThrow(
       'Not a valid element that has a value attribute. Please insert an element that has a value.'
-    );
+    )
     expect(() => expect($link).toHaveValue('link')).toThrow(
       'Not a valid element that has a value attribute. Please insert an element that has a value.'
-    );
-  });
+    )
+  })
 
   it('requires the correct value', () => {
     expect(() => expect($textInput).toHaveValue('random')).toThrow(
       'Expected <input type="text" readonly="" value="text"> to have value=random'
-    );
+    )
     expect(() => expect($numberInput).toHaveValue(11)).toThrow(
       'Expected <input type="number" readonly="" value="10"> to have value=11'
-    );
+    )
     expect(() => expect($textarea).toHaveValue('random')).toThrow(
       'Expected <textarea readonly=""> to have value=random'
-    );
+    )
     expect(() => expect($select).toHaveValue('first')).toThrow(
       'Expected <select> to have value=first'
-    );
-  });
+    )
+  })
 
   it('requires correct negative assertions', () => {
     expect(() => expect($textInput).not.toHaveValue('text')).toThrow(
       'Expected <input type="text" readonly="" value="text"> not to have value=text'
-    );
+    )
     expect(() => expect($numberInput).not.toHaveValue(10)).toThrow(
       'Expected <input type="number" readonly="" value="10"> not to have value=10'
-    );
+    )
     expect(() => expect($textarea).not.toHaveValue('text description')).toThrow(
       'Expected <textarea readonly=""> not to have value=text description'
-    );
+    )
     expect(() => expect($select).not.toHaveValue('second')).toThrow(
       'Expected <select> not to have value=second'
-    );
-  });
-});
+    )
+  })
+})

--- a/src/jest-matchers/toMatchSelector/index.js
+++ b/src/jest-matchers/toMatchSelector/index.js
@@ -1,26 +1,26 @@
-import { normalize, getPlainTag } from '../../helpers';
+import { normalize, getPlainTag } from '../../helpers'
 
 export default function (frag, selectorStr) {
   // To avoid double negations ¯\_(ツ)_/¯
-  this.affirmative = !this.isNot;
+  this.affirmative = !this.isNot
 
   // Convert it into a plain array of nodes
-  frag = normalize(frag);
+  frag = normalize(frag)
 
-  for (let el of frag) {
-    const base = getPlainTag(el);
-    const matches = el.matches(selectorStr);
+  for (const el of frag) {
+    const base = getPlainTag(el)
+    const matches = el.matches(selectorStr)
 
     if (this.affirmative && !matches) {
-      const msg = `Expected ${base} to match selector, ${selectorStr}`;
-      return { pass: false, message: () => msg };
+      const msg = `Expected ${base} to match selector, ${selectorStr}`
+      return { pass: false, message: () => msg }
     }
 
     if (this.isNot && matches) {
-      const msg = `Expected ${base} not to match selector, ${selectorStr}`;
-      return { pass: true, message: () => msg };
+      const msg = `Expected ${base} not to match selector, ${selectorStr}`
+      return { pass: true, message: () => msg }
     }
   }
 
-  return { pass: !this.isNot };
+  return { pass: !this.isNot }
 }

--- a/src/jest-matchers/toMatchSelector/test.js
+++ b/src/jest-matchers/toMatchSelector/test.js
@@ -1,84 +1,84 @@
-import React from "react";
-import $ from "../../";
-import "../index.js";
+import React from 'react'
+import $ from '../../'
+import '../index.js'
 
 const $button = $(
-  <button id="the-button" className="a-button">
+  <button id='the-button' className='a-button'>
     click
   </button>
-);
+)
 const $nestedButton = $(
-  <div id="one">
-    <div id="two">
+  <div id='one'>
+    <div id='two'>
       <button>click</button>
     </div>
   </div>
-);
+)
 
-describe(".toMatchSelector()", () => {
-  it("works for a simple case", () => {
-    expect($button).toMatchSelector("#the-button");
-    expect($button).toMatchSelector(".a-button");
-    expect($nestedButton.find("button")).toMatchSelector("#one #two button");
-  });
+describe('.toMatchSelector()', () => {
+  it('works for a simple case', () => {
+    expect($button).toMatchSelector('#the-button')
+    expect($button).toMatchSelector('.a-button')
+    expect($nestedButton.find('button')).toMatchSelector('#one #two button')
+  })
 
-  it("requires an HTMLelement", () => {
-    const msg = "expect() should receive an HTMLElement or React Test instance";
-    expect(() => expect(null).toMatchSelector(".kiwi")).toThrow(msg);
-    expect(() => expect("random").toMatchSelector(".kiwi")).toThrow(msg);
-  });
+  it('requires an HTMLelement', () => {
+    const msg = 'expect() should receive an HTMLElement or React Test instance'
+    expect(() => expect(null).toMatchSelector('.kiwi')).toThrow(msg)
+    expect(() => expect('random').toMatchSelector('.kiwi')).toThrow(msg)
+  })
 
-  it("requires a valid instance", () => {
-    expect(() => expect({}).toMatchSelector(".kiwi")).toThrow(
-      "expect() should receive an HTMLElement or React Test instance"
-    );
-  });
+  it('requires a valid instance', () => {
+    expect(() => expect({}).toMatchSelector('.kiwi')).toThrow(
+      'expect() should receive an HTMLElement or React Test instance'
+    )
+  })
 
-  it("requires the correct selector", () => {
-    expect(() => expect($button).toMatchSelector(".the-button")).toThrow(
+  it('requires the correct selector', () => {
+    expect(() => expect($button).toMatchSelector('.the-button')).toThrow(
       'Expected <button id="the-button" class="a-button"> to match selector, .the-button'
-    );
-  });
+    )
+  })
 
-  it("negatively asserts unmatched selectors", () => {
-    expect($button).not.toMatchSelector(".the-button");
+  it('negatively asserts unmatched selectors', () => {
+    expect($button).not.toMatchSelector('.the-button')
 
     // throws when selector exists when negatively asserting
-    expect(() => expect($button).not.toMatchSelector(".a-button")).toThrow(
+    expect(() => expect($button).not.toMatchSelector('.a-button')).toThrow(
       'Expected <button id="the-button" class="a-button"> not to match selector, .a-button'
-    );
-  });
+    )
+  })
 
-  describe("multiple elements", () => {
+  describe('multiple elements', () => {
     const $list = $(
       <ul>
-        <li id="first-list-item" className="list-item">
+        <li id='first-list-item' className='list-item'>
           apple
         </li>
-        <li className="list-item">apple</li>
+        <li className='list-item'>apple</li>
       </ul>
-    );
+    )
 
-    it("requires all elements to have the same selector", () => {
-      expect($list.find("li")).toMatchSelector(".list-item");
+    it('requires all elements to have the same selector', () => {
+      expect($list.find('li')).toMatchSelector('.list-item')
 
       // Throws error on the first un-matched selector
       expect(() =>
-        expect($list.find("li")).toMatchSelector("#impossible")
+        expect($list.find('li')).toMatchSelector('#impossible')
       ).toThrow(
         'Expected <li id="first-list-item" class="list-item"> to match selector, #impossible'
-      );
-    });
+      )
+    })
 
-    it("requires all elements to not have the same selector", () => {
-      expect($list.find("li")).not.toMatchSelector("#impossible");
+    it('requires all elements to not have the same selector', () => {
+      expect($list.find('li')).not.toMatchSelector('#impossible')
 
       // At least one item has the id, first-list-item
       expect(() =>
-        expect($list.find("li")).not.toMatchSelector("#first-list-item")
+        expect($list.find('li')).not.toMatchSelector('#first-list-item')
       ).toThrow(
         'Expected <li id="first-list-item" class="list-item"> not to match selector, #first-list-item'
-      );
-    });
-  });
-});
+      )
+    })
+  })
+})

--- a/src/lint.test.js
+++ b/src/lint.test.js
@@ -1,33 +1,33 @@
-const CLIEngine = require("eslint").CLIEngine;
+const CLIEngine = require('eslint').CLIEngine
 
 const getLinterErrors = files => {
-  const cli = new CLIEngine();
-  const { results } = cli.executeOnFiles(files);
+  const cli = new CLIEngine()
+  const { results } = cli.executeOnFiles(files)
   // Cleans the path to make it nice and readable
-  const clean = path => path.replace(process.cwd(), "").replace(/^\//, "");
+  const clean = path => path.replace(process.cwd(), '').replace(/^\//, '')
   return results.map(rep => ({
     file: clean(rep.filePath),
     errors: rep.messages.filter(msg => msg.severity === 2),
     warnings: rep.messages.filter(msg => msg.severity === 1)
-  }));
-};
+  }))
+}
 
-const formatErrors = err => `  [${err.line}:${err.column}] ${err.message}`;
-const formatFiles = (file, messages, type = "error") =>
+const formatErrors = err => `  [${err.line}:${err.column}] ${err.message}`
+const formatFiles = (file, messages, type = 'error') =>
   `Linter ${type}${
-    messages.length > 1 ? "s" : ""
-  } on "${file}":\n${messages.map(formatErrors).join("\n")}`;
+    messages.length > 1 ? 's' : ''
+  } on "${file}":\n${messages.map(formatErrors).join('\n')}`
 
-describe("Linter", () => {
-  getLinterErrors("src").forEach(report => {
+describe('Linter', () => {
+  getLinterErrors('src').forEach(report => {
     it(report.file, () => {
       if (report.warnings.length) {
-        console.warn(formatFiles(report.file, report.warnings, "warning"));
+        console.warn(formatFiles(report.file, report.warnings, 'warning'))
       }
 
       if (report.errors.length) {
-        throw new Error(formatFiles(report.file, report.errors, "error"));
+        throw new Error(formatFiles(report.file, report.errors, 'error'))
       }
-    });
-  });
-});
+    })
+  })
+})

--- a/src/methods/attr/index.js
+++ b/src/methods/attr/index.js
@@ -1,6 +1,6 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.attr = function(key) {
-  const node = this.first();
-  return node && node.getAttribute(key);
-};
+$.prototype.attr = function (key) {
+  const node = this.first()
+  return node && node.getAttribute(key)
+}

--- a/src/methods/attr/test.js
+++ b/src/methods/attr/test.js
@@ -1,27 +1,27 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
 const $base = $(
-  <div className="test" disabled>
+  <div className='test' disabled>
     Hello
   </div>
-);
+)
 
-describe(".attr()", () => {
-  it("should be a function", () => {
-    expect(typeof $(<div />).attr).toBe("function");
-  });
+describe('.attr()', () => {
+  it('should be a function', () => {
+    expect(typeof $(<div />).attr).toBe('function')
+  })
 
-  it("Has the correct html", () => {
-    expect($base.attr("class")).toBe("test");
-    expect($base.attr("disabled")).toBe("");
+  it('Has the correct html', () => {
+    expect($base.attr('class')).toBe('test')
+    expect($base.attr('disabled')).toBe('')
 
     // We test attributes, not properties
-    expect($base.attr("className")).toBe(null);
-  });
+    expect($base.attr('className')).toBe(null)
+  })
 
-  it("works with no matched elements", () => {
-    expect($base.find("button").attr("title")).toBe(null);
-  });
-});
+  it('works with no matched elements', () => {
+    expect($base.find('button').attr('title')).toBe(null)
+  })
+})

--- a/src/methods/children/index.js
+++ b/src/methods/children/index.js
@@ -1,7 +1,7 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.children = function(selector = "*") {
+$.prototype.children = function (selector = '*') {
   return this.map(node => {
-    return [...node.childNodes].filter(node => node.matches(selector));
-  });
-};
+    return [...node.childNodes].filter(node => node.matches(selector))
+  })
+}

--- a/src/methods/children/test.js
+++ b/src/methods/children/test.js
@@ -1,18 +1,18 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".children()", () => {
-  it("Has the correct html without selector", async () => {
+describe('.children()', () => {
+  it('Has the correct html without selector', async () => {
     const $hello = $(
       <div>
         <button>Hello</button>
       </div>
-    );
-    expect($hello.children().first().nodeName).toBe("BUTTON");
-  });
+    )
+    expect($hello.children().first().nodeName).toBe('BUTTON')
+  })
 
-  it("Has the correct nested html without selector", async () => {
+  it('Has the correct nested html without selector', async () => {
     const $hello = $(
       <div>
         <a>
@@ -24,24 +24,24 @@ describe(".children()", () => {
           <li>B</li>
         </ul>
       </div>
-    );
+    )
     const names = $hello
       .children()
       .toArray()
-      .map(node => node.nodeName);
-    expect(names).toEqual(["A", "UL"]);
-  });
+      .map(node => node.nodeName)
+    expect(names).toEqual(['A', 'UL'])
+  })
 
-  it("Has the correct html with selector", async () => {
+  it('Has the correct html with selector', async () => {
     const $hello = $(
       <div>
         <button>Hello</button>
       </div>
-    );
-    expect($hello.children("button").first().nodeName).toBe("BUTTON");
-  });
+    )
+    expect($hello.children('button').first().nodeName).toBe('BUTTON')
+  })
 
-  it("Has the correct nested html with selector", async () => {
+  it('Has the correct nested html with selector', async () => {
     const $hello = $(
       <div>
         <a>
@@ -53,15 +53,15 @@ describe(".children()", () => {
           <li>B</li>
         </ul>
       </div>
-    );
+    )
     const names = $hello
-      .children("ul")
+      .children('ul')
       .toArray()
-      .map(node => node.nodeName);
-    expect(names).toEqual(["UL"]);
-  });
+      .map(node => node.nodeName)
+    expect(names).toEqual(['UL'])
+  })
 
-  it("Can be chained", async () => {
+  it('Can be chained', async () => {
     const $hello = $(
       <div>
         <a>
@@ -69,16 +69,16 @@ describe(".children()", () => {
           <span>World</span>
         </a>
       </div>
-    );
+    )
     const names = $hello
-      .children("a")
-      .find("button")
+      .children('a')
+      .find('button')
       .toArray()
-      .map(node => node.nodeName);
-    expect(names).toEqual(["BUTTON"]);
-  });
+      .map(node => node.nodeName)
+    expect(names).toEqual(['BUTTON'])
+  })
 
-  it("Can get children of multiple nodes", async () => {
+  it('Can get children of multiple nodes', async () => {
     const $hello = $(
       <div>
         <p>
@@ -94,13 +94,13 @@ describe(".children()", () => {
           </a>
         </p>
       </div>
-    );
+    )
     const names = $hello
-      .find("p")
-      .children("a")
-      .find("button")
+      .find('p')
+      .children('a')
+      .find('button')
       .toArray()
-      .map(node => node.nodeName);
-    expect(names).toEqual(["BUTTON", "BUTTON"]);
-  });
-});
+      .map(node => node.nodeName)
+    expect(names).toEqual(['BUTTON', 'BUTTON'])
+  })
+})

--- a/src/methods/click/index.js
+++ b/src/methods/click/index.js
@@ -1,9 +1,9 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
 // Right now this is forced to be async just for the sake of it (from trigger).
 // This is because I'm fairly confident the final API will be async
-$.prototype.click = function(...args) {
-  const selector = args.find(a => typeof a === "string");
-  const time = args.find(a => typeof a === "number");
-  return this.find(selector).trigger("click", time);
-};
+$.prototype.click = function (...args) {
+  const selector = args.find(a => typeof a === 'string')
+  const time = args.find(a => typeof a === 'number')
+  return this.find(selector).trigger('click', time)
+}

--- a/src/methods/click/test.js
+++ b/src/methods/click/test.js
@@ -1,215 +1,215 @@
-import React, { useEffect, useState } from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React, { useEffect, useState } from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-const delay = time => new Promise(done => setTimeout(done, time));
+const delay = (time) => new Promise((resolve) => setTimeout(resolve, time))
 
-describe(".click()", () => {
-  it("can attach and click on children", async () => {
-    const mock = jest.fn();
+describe('.click()', () => {
+  it('can attach and click on children', async () => {
+    const mock = jest.fn()
     const $test = $(
       <div>
         <div onClick={mock} />
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.find("div").click();
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.find('div').click()
+    expect(mock).toBeCalled()
+  })
 
-  it("can click and submit buttons", async () => {
-    const mock = jest.fn();
+  it('can click and submit buttons', async () => {
+    const mock = jest.fn()
     const $form = $(
       <form
-        onSubmit={e => {
-          e.preventDefault();
-          mock();
+        onSubmit={(e) => {
+          e.preventDefault()
+          mock()
         }}
       >
-        <button name="submit">Hello</button>
+        <button name='submit'>Hello</button>
       </form>
-    );
-    expect(mock).not.toBeCalled();
-    await $form.find("button").click();
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $form.find('button').click()
+    expect(mock).toBeCalled()
+  })
 
-  it("can listen to document clicks", async () => {
-    const mock = jest.fn();
+  it('can listen to document clicks', async () => {
+    const mock = jest.fn()
     const DocClick = () => {
-      const [counter, setCounter] = useState(0);
+      const [counter, setCounter] = useState(0)
       const increment = () => {
-        mock();
-        setCounter(counter + 1);
-      };
+        mock()
+        setCounter(counter + 1)
+      }
       useEffect(() => {
-        document.addEventListener("click", increment);
-        return () => document.removeEventListener("click", increment);
-      }, [counter]);
-      return <button>{counter}</button>;
-    };
-    const $button = $(<DocClick />);
-    expect(mock).not.toBeCalled();
-    expect($button.text()).toBe("0");
-    await $button.click();
-    expect(mock).toBeCalled();
-    expect($button.text()).toBe("1");
-  });
+        document.addEventListener('click', increment)
+        return () => document.removeEventListener('click', increment)
+      }, [counter])
+      return <button>{counter}</button>
+    }
+    const $button = $(<DocClick />)
+    expect(mock).not.toBeCalled()
+    expect($button.text()).toBe('0')
+    await $button.click()
+    expect(mock).toBeCalled()
+    expect($button.text()).toBe('1')
+  })
 
-  it("returns a promise", async () => {
-    const mock = jest.fn();
+  it('returns a promise', async () => {
+    const mock = jest.fn()
     const $test = $(
       <div>
         <div
           onClick={async () => {
-            await delay(100);
-            mock();
+            await delay(100)
+            mock()
           }}
         />
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.click("div", 200);
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.click('div', 200)
+    expect(mock).toBeCalled()
+  })
 
-  it("can click two children", async () => {
-    const mock1 = jest.fn();
-    const mock2 = jest.fn();
+  it('can click two children', async () => {
+    const mock1 = jest.fn()
+    const mock2 = jest.fn()
     const $test = $(
       <div>
         <div onClick={mock1} />
         <div onClick={mock2} />
       </div>
-    );
-    expect(mock1).not.toBeCalled();
-    expect(mock2).not.toBeCalled();
-    await $test.click("div");
-    expect(mock1).toBeCalled();
-    expect(mock2).toBeCalled();
-  });
+    )
+    expect(mock1).not.toBeCalled()
+    expect(mock2).not.toBeCalled()
+    await $test.click('div')
+    expect(mock1).toBeCalled()
+    expect(mock2).toBeCalled()
+  })
 
-  it("can click only on the first one", async () => {
-    const mock = jest.fn();
-    const badmock = jest.fn();
+  it('can click only on the first one', async () => {
+    const mock = jest.fn()
+    const badmock = jest.fn()
     const $test = $(
       <div>
         <span onClick={mock} />
         <div onClick={badmock} />
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.click("span");
-    expect(mock).toBeCalled();
-    expect(badmock).not.toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.click('span')
+    expect(mock).toBeCalled()
+    expect(badmock).not.toBeCalled()
+  })
 
-  it("works with different prop names", async () => {
-    const Button = ({ run, ...props }) => <div onClick={run} {...props} />;
-    const mock = jest.fn();
-    const $test = $(<Button run={mock}>Hi</Button>);
-    expect(mock).not.toBeCalled();
-    await $test.click();
-    expect(mock).toBeCalled();
-  });
+  it('works with different prop names', async () => {
+    const Button = ({ run, ...props }) => <div onClick={run} {...props} />
+    const mock = jest.fn()
+    const $test = $(<Button run={mock}>Hi</Button>)
+    expect(mock).not.toBeCalled()
+    await $test.click()
+    expect(mock).toBeCalled()
+  })
 
-  it("works with async and no wait", async () => {
-    const mock = jest.fn();
+  it('works with async and no wait', async () => {
+    const mock = jest.fn()
     const $test = $(
       <div onClick={async () => mock()}>
         <div>Hi</div>
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.click("div");
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.click('div')
+    expect(mock).toBeCalled()
+  })
 
-  it.skip("works with async and waiting", async () => {
-    const mock = jest.fn();
+  it.skip('works with async and waiting', async () => {
+    const mock = jest.fn()
     const $test = $(
       <div
         onClick={async () => {
-          await delay(100);
-          mock();
+          await delay(100)
+          mock()
         }}
       >
         Hi
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.click();
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.click()
+    expect(mock).toBeCalled()
+  })
 
-  it("will bubble up", async () => {
-    const mock = jest.fn();
+  it('will bubble up', async () => {
+    const mock = jest.fn()
     const $test = $(
       <div onClick={mock}>
         <div>Hi</div>
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.click("div");
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.click('div')
+    expect(mock).toBeCalled()
+  })
 
   it("won't throw when clicking on unfound children", async () => {
-    const mock = jest.fn();
+    const mock = jest.fn()
     const $test = $(
       <div>
         <div onClick={mock}>Hi</div>
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.click("a");
-    expect(mock).not.toBeCalled();
-    await $test.click("div");
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.click('a')
+    expect(mock).not.toBeCalled()
+    await $test.click('div')
+    expect(mock).toBeCalled()
+  })
 
   it("won't throw when clicking on children with no props", async () => {
-    const mock = jest.fn();
+    const mock = jest.fn()
     const $test = $(
       <div>
         <div onClick={mock}>Hi</div>
       </div>
-    );
-    expect(mock).not.toBeCalled();
-    await $test.click();
-    expect(mock).not.toBeCalled();
-    await $test.click("div");
-    expect(mock).toBeCalled();
-  });
+    )
+    expect(mock).not.toBeCalled()
+    await $test.click()
+    expect(mock).not.toBeCalled()
+    await $test.click('div')
+    expect(mock).toBeCalled()
+  })
 
   it("won't throw when clicking on children with no onClick", async () => {
     const $test = $(
       <div>
         <div>Hi</div>
       </div>
-    );
-    await $test.click();
-    await $test.click("div");
-  });
+    )
+    await $test.click()
+    await $test.click('div')
+  })
 
-  it("works with native links", async () => {
-    const mock = jest.fn();
+  it('works with native links', async () => {
+    const mock = jest.fn()
     const Page = () => {
       useEffect(() => {
-        document.addEventListener("click", mock);
-        return () => document.removeEventListener("click", mock);
-      }, []);
+        document.addEventListener('click', mock)
+        return () => document.removeEventListener('click', mock)
+      }, [])
 
       return (
         <div>
           <a>Click me</a>
         </div>
-      );
-    };
+      )
+    }
 
-    const $test = $(<Page />);
-    expect(mock).not.toBeCalled();
-    await $test.click("a");
-    expect(mock).toBeCalled();
-  });
-});
+    const $test = $(<Page />)
+    expect(mock).not.toBeCalled()
+    await $test.click('a')
+    expect(mock).toBeCalled()
+  })
+})

--- a/src/methods/closest/index.js
+++ b/src/methods/closest/index.js
@@ -1,5 +1,5 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.closest = function(selector = "*") {
-  return this.map(node => node.closest(selector));
-};
+$.prototype.closest = function (selector = '*') {
+  return this.map(node => node.closest(selector))
+}

--- a/src/methods/closest/test.js
+++ b/src/methods/closest/test.js
@@ -1,28 +1,28 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".closest()", () => {
-  it("Has the correct html when match itself", async () => {
+describe('.closest()', () => {
+  it('Has the correct html when match itself', async () => {
     const $hello = $(
       <div>
         <button>Hello</button>
       </div>
-    );
-    expect($hello.closest("div").first().nodeName).toBe("DIV");
-  });
+    )
+    expect($hello.closest('div').first().nodeName).toBe('DIV')
+  })
 
-  it("Will default to self", async () => {
-    const $hello = $(<button>Hello</button>);
-    expect($hello.closest().first().nodeName).toBe("BUTTON");
-  });
+  it('Will default to self', async () => {
+    const $hello = $(<button>Hello</button>)
+    expect($hello.closest().first().nodeName).toBe('BUTTON')
+  })
 
-  it("Will have no nodes when no match is found", async () => {
-    const $hello = $(<button>Hello</button>);
-    expect($hello.closest("a").toArray()).toEqual([]);
-  });
+  it('Will have no nodes when no match is found', async () => {
+    const $hello = $(<button>Hello</button>)
+    expect($hello.closest('a').toArray()).toEqual([])
+  })
 
-  it("Has the correct html when match parent", async () => {
+  it('Has the correct html when match parent', async () => {
     const $hello = $(
       <div>
         <a>
@@ -30,15 +30,15 @@ describe(".closest()", () => {
           <span>World</span>
         </a>
       </div>
-    );
+    )
     const names = $hello
-      .find("button")
-      .closest("a")
-      .first().nodeName;
-    expect(names).toBe("A");
-  });
+      .find('button')
+      .closest('a')
+      .first().nodeName
+    expect(names).toBe('A')
+  })
 
-  it("Has the correct html when match parent from multiple children", async () => {
+  it('Has the correct html when match parent from multiple children', async () => {
     const $hello = $(
       <div>
         <ul>
@@ -46,15 +46,15 @@ describe(".closest()", () => {
           <li>World</li>
         </ul>
       </div>
-    );
+    )
     const names = $hello
-      .find("li")
-      .closest("ul")
-      .first().nodeName;
-    expect(names).toBe("UL");
-  });
+      .find('li')
+      .closest('ul')
+      .first().nodeName
+    expect(names).toBe('UL')
+  })
 
-  it("Has the correct html when match multiple parents from multiple children", async () => {
+  it('Has the correct html when match multiple parents from multiple children', async () => {
     const List = () => (
       <ul>
         <li>
@@ -64,18 +64,18 @@ describe(".closest()", () => {
           <a>World</a>
         </li>
       </ul>
-    );
+    )
 
     // This should return both of the <li>s
     const names = $(<List />)
-      .find("a")
-      .closest("li")
+      .find('a')
+      .closest('li')
       .toArray()
-      .map(node => node.nodeName);
-    expect(names).toEqual(["LI", "LI"]);
-  });
+      .map(node => node.nodeName)
+    expect(names).toEqual(['LI', 'LI'])
+  })
 
-  it("Has the correct html when match single parent from multiple children", async () => {
+  it('Has the correct html when match single parent from multiple children', async () => {
     const List = () => (
       <div>
         <ul>
@@ -87,14 +87,14 @@ describe(".closest()", () => {
           </li>
         </ul>
       </div>
-    );
+    )
 
     // This should return both of the <li>s
     const names = $(<List />)
-      .find("a")
-      .closest("ul")
+      .find('a')
+      .closest('ul')
       .toArray()
-      .map(node => node.nodeName);
-    expect(names).toEqual(["UL"]);
-  });
-});
+      .map(node => node.nodeName)
+    expect(names).toEqual(['UL'])
+  })
+})

--- a/src/methods/constructor.js
+++ b/src/methods/constructor.js
@@ -1,38 +1,38 @@
-import render from "./render";
-import { act } from "react-dom/test-utils";
+import render from './render'
+import { act } from 'react-dom/test-utils'
 
-const $ = function ReactTest(obj, ctx = {}) {
-  if (!(this instanceof $)) return new $(obj, ctx);
+const $ = function ReactTest (obj, ctx = {}) {
+  if (!(this instanceof $)) return new $(obj, ctx)
 
-  this.events = ctx.events || {};
-  this.window = ctx.window;
+  this.events = ctx.events || {}
+  this.window = ctx.window
 
   act(() => {
     window.addEventListener = (event, callback) => {
-      this.events[event] = this.events[event] || [];
-      this.events[event].push(callback);
-    };
+      this.events[event] = this.events[event] || []
+      this.events[event].push(callback)
+    }
 
     document.addEventListener = (event, callback) => {
-      this.events[event] = this.events[event] || [];
-      this.events[event].push(callback);
-    };
-
-    const [nodes, newWindow] = render(obj);
-    this.nodes = nodes;
-    if (!this.window && newWindow) {
-      this.window = newWindow;
+      this.events[event] = this.events[event] || []
+      this.events[event].push(callback)
     }
-  });
 
-  return this;
-};
+    const [nodes, newWindow] = render(obj)
+    this.nodes = nodes
+    if (!this.window && newWindow) {
+      this.window = newWindow
+    }
+  })
+
+  return this
+}
 
 // Allow to iterate with for...of and destructure it like [...$list.find('li')]
-$.prototype[Symbol.iterator] = function*() {
-  for (let node of this.nodes) {
-    yield node;
+$.prototype[Symbol.iterator] = function * () {
+  for (const node of this.nodes) {
+    yield node
   }
-};
+}
 
-export default $;
+export default $

--- a/src/methods/constructor.test.js
+++ b/src/methods/constructor.test.js
@@ -1,68 +1,68 @@
-import React, { useEffect } from "react";
-import $ from "../";
-import "babel-polyfill";
+import React, { useEffect } from 'react'
+import $ from '../'
+import 'babel-polyfill'
 
-describe("Iterator", () => {
-  it("has the correct names", () => {
-    const $button = $(<button>Hello</button>);
-    expect($button.constructor.name).toBe("ReactTest");
-  });
+describe('Iterator', () => {
+  it('has the correct names', () => {
+    const $button = $(<button>Hello</button>)
+    expect($button.constructor.name).toBe('ReactTest')
+  })
 
-  it("can convert to an array with destructuring", () => {
+  it('can convert to an array with destructuring', () => {
     const html = $(
       <ul>
         <li>A</li>
         <li>B</li>
       </ul>
-    );
-    expect([...html.find("li")]).toHaveLength(2);
-    expect([...html.find("li")].map(el => el.nodeName)).toEqual(["LI", "LI"]);
-  });
+    )
+    expect([...html.find('li')]).toHaveLength(2)
+    expect([...html.find('li')].map(el => el.nodeName)).toEqual(['LI', 'LI'])
+  })
 
-  it("can iterate the values with for...of", () => {
+  it('can iterate the values with for...of', () => {
     const html = $(
       <ul>
         <li>A</li>
         <li>B</li>
       </ul>
-    );
-    let total = 0;
-    for (let item of html.find("li")) {
-      expect(item.nodeName).toBe("LI");
-      total++;
+    )
+    let total = 0
+    for (const item of html.find('li')) {
+      expect(item.nodeName).toBe('LI')
+      total++
     }
-    expect(total).toBe(2);
-  });
+    expect(total).toBe(2)
+  })
 
-  it("can wrap the iterable", () => {
+  it('can wrap the iterable', () => {
     const html = $(
       <ul>
         <li>A</li>
         <li>B</li>
       </ul>
-    );
-    let total = 0;
-    for (let item of html.find("li")) {
-      expect($(item).get(0).nodeName).toBe("LI");
-      total++;
+    )
+    let total = 0
+    for (const item of html.find('li')) {
+      expect($(item).get(0).nodeName).toBe('LI')
+      total++
     }
-    expect(total).toBe(2);
-  });
+    expect(total).toBe(2)
+  })
 
-  it("can use hooks", () => {
+  it('can use hooks', () => {
     const CompWithHook = () => {
       useEffect(() => {
         // Nothing going on here
-      }, []);
-      return <div>Hi</div>;
-    };
-    const $hooked = $(<CompWithHook />);
-    expect($hooked.html()).toBe(`<div>Hi</div>`);
-  });
+      }, [])
+      return <div>Hi</div>
+    }
+    const $hooked = $(<CompWithHook />)
+    expect($hooked.html()).toBe('<div>Hi</div>')
+  })
 
-  it("can be double rendered", () => {
-    const html = $(<div>Abc</div>);
-    expect(html.nodes[0].outerHTML).toEqual(`<div>Abc</div>`);
-    expect(html.nodes[0].nodeName).toBe("DIV");
-  });
-});
+  it('can be double rendered', () => {
+    const html = $(<div>Abc</div>)
+    expect(html.nodes[0].outerHTML).toEqual('<div>Abc</div>')
+    expect(html.nodes[0].nodeName).toBe('DIV')
+  })
+})

--- a/src/methods/data/index.js
+++ b/src/methods/data/index.js
@@ -1,5 +1,5 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.data = function(value) {
-  return this.attr(`data-${value}`);
-};
+$.prototype.data = function (value) {
+  return this.attr(`data-${value}`)
+}

--- a/src/methods/data/test.js
+++ b/src/methods/data/test.js
@@ -1,14 +1,14 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".data()", () => {
-  it("returns the correct value when reading a data-attribute", () => {
-    const $hello = $(<div data-id="0">Hello</div>);
-    expect($hello.data("id")).toBe("0");
-  });
-  it("returns null if the data-attribute is not present in the node", () => {
-    const $hello = $(<div id="0">Hello</div>);
-    expect($hello.data("id")).toBe(null);
-  });
-});
+describe('.data()', () => {
+  it('returns the correct value when reading a data-attribute', () => {
+    const $hello = $(<div data-id='0'>Hello</div>)
+    expect($hello.data('id')).toBe('0')
+  })
+  it('returns null if the data-attribute is not present in the node', () => {
+    const $hello = $(<div id='0'>Hello</div>)
+    expect($hello.data('id')).toBe(null)
+  })
+})

--- a/src/methods/find/index.js
+++ b/src/methods/find/index.js
@@ -1,6 +1,6 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.find = function(selector) {
-  if (!selector) return this;
-  return this.map(node => [...node.querySelectorAll(selector)]);
-};
+$.prototype.find = function (selector) {
+  if (!selector) return this
+  return this.map(node => [...node.querySelectorAll(selector)])
+}

--- a/src/methods/find/test.js
+++ b/src/methods/find/test.js
@@ -1,18 +1,18 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".find()", () => {
-  it("will get tag that we want", async () => {
+describe('.find()', () => {
+  it('will get tag that we want', async () => {
     const $hello = $(
       <div>
         <button>Hello</button>
       </div>
-    );
-    expect($hello.find("button").first().nodeName).toBe("BUTTON");
-  });
+    )
+    expect($hello.find('button').first().nodeName).toBe('BUTTON')
+  })
 
-  it("can match every successor", async () => {
+  it('can match every successor', async () => {
     const $hello = $(
       <div>
         <a>
@@ -20,11 +20,11 @@ describe(".find()", () => {
           <span>World</span>
         </a>
       </div>
-    );
+    )
     const names = $hello
-      .find("*")
+      .find('*')
       .toArray()
-      .map(node => node.nodeName);
-    expect(names).toEqual(["A", "BUTTON", "SPAN"]);
-  });
-});
+      .map(node => node.nodeName)
+    expect(names).toEqual(['A', 'BUTTON', 'SPAN'])
+  })
+})

--- a/src/methods/first/index.js
+++ b/src/methods/first/index.js
@@ -1,5 +1,5 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.first = function() {
-  return this.get(0) || null;
-};
+$.prototype.first = function () {
+  return this.get(0) || null
+}

--- a/src/methods/first/test.js
+++ b/src/methods/first/test.js
@@ -1,6 +1,6 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
 const $list = $(
   <ul>
@@ -8,14 +8,14 @@ const $list = $(
     <li>B</li>
     <li>C</li>
   </ul>
-);
+)
 
-describe(".first()", () => {
-  it("returns the top-level tag by default", async () => {
-    expect($list.first().nodeName).toBe("UL");
-  });
+describe('.first()', () => {
+  it('returns the top-level tag by default', async () => {
+    expect($list.first().nodeName).toBe('UL')
+  })
 
-  it("returns the first item of a list", async () => {
-    expect($list.find("li").first().textContent).toEqual("A");
-  });
-});
+  it('returns the first item of a list', async () => {
+    expect($list.find('li').first().textContent).toEqual('A')
+  })
+})

--- a/src/methods/get/index.js
+++ b/src/methods/get/index.js
@@ -1,8 +1,8 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
 // Removed duplicated nodes, used for some specific methods
-$.prototype.get = function(index = 0) {
-  const array = this.toArray();
-  if (index < 0) index = array.length + index;
-  return array[index];
-};
+$.prototype.get = function (index = 0) {
+  const array = this.toArray()
+  if (index < 0) index = array.length + index
+  return array[index]
+}

--- a/src/methods/html/index.js
+++ b/src/methods/html/index.js
@@ -1,6 +1,6 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.html = function() {
-  const node = this.first();
-  return node ? node.outerHTML : "";
-};
+$.prototype.html = function () {
+  const node = this.first()
+  return node ? node.outerHTML : ''
+}

--- a/src/methods/html/test.js
+++ b/src/methods/html/test.js
@@ -1,36 +1,36 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".html()", () => {
-  it("can get the plain html", () => {
-    const $hello = $(<button>Hello</button>);
-    expect($hello.html()).toBe(`<button>Hello</button>`);
-  });
+describe('.html()', () => {
+  it('can get the plain html', () => {
+    const $hello = $(<button>Hello</button>)
+    expect($hello.html()).toBe('<button>Hello</button>')
+  })
 
-  it("can get nested children", () => {
+  it('can get nested children', () => {
     const $hello = $(
-      <div className="hello">
+      <div className='hello'>
         <button>Hello</button>
       </div>
-    );
+    )
     expect($hello.html()).toBe(
-      `<div class="hello"><button>Hello</button></div>`
-    );
-  });
+      '<div class="hello"><button>Hello</button></div>'
+    )
+  })
 
-  it("only gets the first child", () => {
+  it('only gets the first child', () => {
     const $hello = $(
-      <div className="hello">
+      <div className='hello'>
         <button>Hello</button>
         <button>World</button>
       </div>
-    );
-    expect($hello.find("button").html()).toBe(`<button>Hello</button>`);
-  });
+    )
+    expect($hello.find('button').html()).toBe('<button>Hello</button>')
+  })
 
-  it("can get a string", () => {
-    const $hello = $(<>Hello</>);
-    expect($hello.text()).toBe(`Hello`);
-  });
-});
+  it('can get a string', () => {
+    const $hello = $(<>Hello</>)
+    expect($hello.text()).toBe('Hello')
+  })
+})

--- a/src/methods/is/index.js
+++ b/src/methods/is/index.js
@@ -1,5 +1,5 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.is = function(selector = "*") {
-  return this.toArray().some(node => node.matches(selector));
-};
+$.prototype.is = function (selector = '*') {
+  return this.toArray().some(node => node.matches(selector))
+}

--- a/src/methods/is/test.js
+++ b/src/methods/is/test.js
@@ -1,16 +1,16 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".is()", () => {
-  it("Has the correct html", async () => {
+describe('.is()', () => {
+  it('Has the correct html', async () => {
     const $hello = $(
       <div>
         <button>Hello</button>
       </div>
-    );
-    expect($hello.is("div")).toBe(true);
-    expect($hello.is("button")).not.toBe(true);
-    expect($hello.find("button").is("button")).toBe(true);
-  });
-});
+    )
+    expect($hello.is('div')).toBe(true)
+    expect($hello.is('button')).not.toBe(true)
+    expect($hello.find('button').is('button')).toBe(true)
+  })
+})

--- a/src/methods/last/index.js
+++ b/src/methods/last/index.js
@@ -1,5 +1,5 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.last = function() {
-  return this.get(-1) || null;
-};
+$.prototype.last = function () {
+  return this.get(-1) || null
+}

--- a/src/methods/last/test.js
+++ b/src/methods/last/test.js
@@ -1,6 +1,6 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
 const $list = $(
   <ul>
@@ -8,14 +8,14 @@ const $list = $(
     <li>B</li>
     <li>C</li>
   </ul>
-);
+)
 
-describe(".last()", () => {
-  it("will get the top-level tag", async () => {
-    expect($list.last().nodeName).toBe("UL");
-  });
+describe('.last()', () => {
+  it('will get the top-level tag', async () => {
+    expect($list.last().nodeName).toBe('UL')
+  })
 
-  it("will get the last of the children", async () => {
-    expect($list.find("li").last().textContent).toEqual("C");
-  });
-});
+  it('will get the last of the children', async () => {
+    expect($list.find('li').last().textContent).toEqual('C')
+  })
+})

--- a/src/methods/map/index.js
+++ b/src/methods/map/index.js
@@ -1,7 +1,7 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
 // The default callback does nothing, just keep it the same
-$.prototype.map = function(callback) {
+$.prototype.map = function (callback) {
   // We don't want to select repeated nodes
   return $(
     this.toArray()
@@ -9,5 +9,5 @@ $.prototype.map = function(callback) {
       .flat()
       .filter(Boolean),
     this
-  ).unique();
-};
+  ).unique()
+}

--- a/src/methods/map/test.js
+++ b/src/methods/map/test.js
@@ -1,6 +1,6 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
 const $list = $(
   <ul>
@@ -8,19 +8,19 @@ const $list = $(
     <li>B</li>
     <li>C</li>
   </ul>
-);
+)
 
-describe(".map()", () => {
-  it("returns an instance of itself", () => {
-    expect($list.map(node => node)).toBeInstanceOf($);
-  });
+describe('.map()', () => {
+  it('returns an instance of itself', () => {
+    expect($list.map(node => node)).toBeInstanceOf($)
+  })
 
-  it("can perform a noop transformation", () => {
-    expect($list.first().nodeName).toBe("UL");
-    expect($list.map(node => node).first().nodeName).toBe("UL");
-  });
+  it('can perform a noop transformation', () => {
+    expect($list.first().nodeName).toBe('UL')
+    expect($list.map(node => node).first().nodeName).toBe('UL')
+  })
 
-  it("needs a callback", () => {
-    expect(() => $list.map()).toThrow();
-  });
-});
+  it('needs a callback', () => {
+    expect(() => $list.map()).toThrow()
+  })
+})

--- a/src/methods/render.js
+++ b/src/methods/render.js
@@ -1,33 +1,33 @@
-import Window from "window";
-import ReactDOM from "react-dom";
+import Window from 'window'
+import ReactDOM from 'react-dom'
 
 const render = component => {
-  const window = new Window();
+  const window = new Window()
 
-  const container = window.document.createElement("div");
-  container.id = "root";
-  window.document.body.appendChild(container);
+  const container = window.document.createElement('div')
+  container.id = 'root'
+  window.document.body.appendChild(container)
 
-  ReactDOM.render(component, container);
+  ReactDOM.render(component, container)
 
-  return [[...container.childNodes], window];
-};
+  return [[...container.childNodes], window]
+}
 
 // This takes a react object like <Button /> and returns the DOM tree
 export default obj => {
-  if (!obj) return [[]];
+  if (!obj) return [[]]
 
-  if (["string", "number", "boolean"].includes(typeof obj)) {
-    return render(obj);
+  if (['string', 'number', 'boolean'].includes(typeof obj)) {
+    return render(obj)
   }
 
   // A react instance, so render it to jsdom:
   if (obj.$$typeof) {
-    return render(obj);
+    return render(obj)
   }
 
   // It's already parsed
   return [
-    (Array.isArray(obj) ? obj : [obj]).filter(obj => typeof obj === "object")
-  ];
-};
+    (Array.isArray(obj) ? obj : [obj]).filter(obj => typeof obj === 'object')
+  ]
+}

--- a/src/methods/render.test.js
+++ b/src/methods/render.test.js
@@ -1,39 +1,39 @@
-import React from "react";
-import render from "./render";
-import "babel-polyfill";
+import React from 'react'
+import render from './render'
+import 'babel-polyfill'
 
-describe("render", () => {
-  it("empty returns an empty array", () => {
-    const [html] = render();
-    expect(html).toEqual([]);
-  });
+describe('render', () => {
+  it('empty returns an empty array', () => {
+    const [html] = render()
+    expect(html).toEqual([])
+  })
 
-  it("will render plain strings", () => {
-    const [html] = render("Hello");
-    expect(html[0].textContent).toEqual("Hello");
-  });
+  it('will render plain strings', () => {
+    const [html] = render('Hello')
+    expect(html[0].textContent).toEqual('Hello')
+  })
 
-  it("will render a string fragment", () => {
-    const [html] = render(<>Hello</>);
-    expect(html[0].textContent).toEqual("Hello");
-  });
+  it('will render a string fragment', () => {
+    const [html] = render(<>Hello</>)
+    expect(html[0].textContent).toEqual('Hello')
+  })
 
-  it("can render a plain Div", () => {
-    const [html] = render(<div>Abc</div>);
-    expect(html[0].outerHTML).toEqual(`<div>Abc</div>`);
-    expect(html[0].nodeName).toBe("DIV");
-  });
+  it('can render a plain Div', () => {
+    const [html] = render(<div>Abc</div>)
+    expect(html[0].outerHTML).toEqual('<div>Abc</div>')
+    expect(html[0].nodeName).toBe('DIV')
+  })
 
-  it("can render a list", () => {
+  it('can render a list', () => {
     const [html] = render(
       <ul>
         <li>A</li>
         <li>B</li>
       </ul>
-    );
-    expect(html[0].outerHTML).toEqual(`<ul><li>A</li><li>B</li></ul>`);
-    expect(html[0].nodeName).toBe("UL");
-    expect(html[0].children).toHaveLength(2);
-    expect(html[0].children[0].nodeName).toBe("LI");
-  });
-});
+    )
+    expect(html[0].outerHTML).toEqual('<ul><li>A</li><li>B</li></ul>')
+    expect(html[0].nodeName).toBe('UL')
+    expect(html[0].children).toHaveLength(2)
+    expect(html[0].children[0].nodeName).toBe('LI')
+  })
+})

--- a/src/methods/submit/index.js
+++ b/src/methods/submit/index.js
@@ -1,9 +1,9 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
 // Right now this is forced to be async just for the sake of it (from trigger).
 // This is because I'm fairly confident the final API will be async
-$.prototype.submit = function(...args) {
-  const selector = args.find(a => typeof a === "string");
-  const time = args.find(a => typeof a === "number");
-  return this.find(selector).trigger("submit", time);
-};
+$.prototype.submit = function (...args) {
+  const selector = args.find(a => typeof a === 'string')
+  const time = args.find(a => typeof a === 'number')
+  return this.find(selector).trigger('submit', time)
+}

--- a/src/methods/submit/test.js
+++ b/src/methods/submit/test.js
@@ -1,35 +1,35 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
 const CreateUser = ({ onSubmit }) => (
   <form
     onSubmit={e => {
-      e.preventDefault();
-      onSubmit();
+      e.preventDefault()
+      onSubmit()
     }}
   >
-    <input name="firstname" />
-    <input name="lastname" />
-    <input name="age" />
+    <input name='firstname' />
+    <input name='lastname' />
+    <input name='age' />
     <button>Submit</button>
   </form>
-);
+)
 
-describe(".submit()", () => {
-  it("can mock submitting a form", async () => {
-    const onSubmit = jest.fn();
-    const createUser = $(<CreateUser onSubmit={onSubmit} />);
-    expect(onSubmit).not.toBeCalled();
-    await createUser.submit();
-    expect(onSubmit).toBeCalled();
-  });
+describe('.submit()', () => {
+  it('can mock submitting a form', async () => {
+    const onSubmit = jest.fn()
+    const createUser = $(<CreateUser onSubmit={onSubmit} />)
+    expect(onSubmit).not.toBeCalled()
+    await createUser.submit()
+    expect(onSubmit).toBeCalled()
+  })
 
-  it("submits the form when clicking the button", async () => {
-    const onSubmit = jest.fn();
-    const createUser = $(<CreateUser onSubmit={onSubmit} />);
-    expect(onSubmit).not.toBeCalled();
-    await createUser.find("button").click();
-    expect(onSubmit).toBeCalled();
-  });
-});
+  it('submits the form when clicking the button', async () => {
+    const onSubmit = jest.fn()
+    const createUser = $(<CreateUser onSubmit={onSubmit} />)
+    expect(onSubmit).not.toBeCalled()
+    await createUser.find('button').click()
+    expect(onSubmit).toBeCalled()
+  })
+})

--- a/src/methods/text/index.js
+++ b/src/methods/text/index.js
@@ -1,6 +1,6 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
-$.prototype.text = function() {
-  const node = this.first();
-  return node ? node.textContent : "";
-};
+$.prototype.text = function () {
+  const node = this.first()
+  return node ? node.textContent : ''
+}

--- a/src/methods/text/test.js
+++ b/src/methods/text/test.js
@@ -1,29 +1,29 @@
-import React from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".html()", () => {
-  it("can get the plain html", () => {
-    const $hello = $(<button>Hello</button>);
-    expect($hello.text()).toBe(`Hello`);
-  });
+describe('.html()', () => {
+  it('can get the plain html', () => {
+    const $hello = $(<button>Hello</button>)
+    expect($hello.text()).toBe('Hello')
+  })
 
-  it("can get nested children", () => {
+  it('can get nested children', () => {
     const $hello = $(
-      <div className="hello">
+      <div className='hello'>
         <button>Hello</button>
       </div>
-    );
-    expect($hello.text()).toBe(`Hello`);
-  });
+    )
+    expect($hello.text()).toBe('Hello')
+  })
 
-  it("only gets the first child", () => {
+  it('only gets the first child', () => {
     const $hello = $(
-      <div className="hello">
+      <div className='hello'>
         <button>Hello</button>
         <button>World</button>
       </div>
-    );
-    expect($hello.find("button").text()).toBe(`Hello`);
-  });
-});
+    )
+    expect($hello.find('button').text()).toBe('Hello')
+  })
+})

--- a/src/methods/toArray/index.js
+++ b/src/methods/toArray/index.js
@@ -1,6 +1,6 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
 // Removed duplicated nodes, used for some specific methods
-$.prototype.toArray = function() {
-  return this.nodes;
-};
+$.prototype.toArray = function () {
+  return this.nodes
+}

--- a/src/methods/trigger/index.js
+++ b/src/methods/trigger/index.js
@@ -3,92 +3,92 @@
 // This is a fairly experimental implementation, it emulates event propagation
 // but doesn't properly handle `e.stopPropagation()`. The nice thing is that
 // it can and will await properly for the async callbacks!
-import { act } from "react-dom/test-utils";
+import { act } from 'react-dom/test-utils'
 
-import $ from "../constructor";
+import $ from '../constructor'
 
 const findParents = (node, list = []) => {
-  list.push(node); // add current node
+  list.push(node) // add current node
   // do recursion until BODY is reached
-  if (node.tagName !== "BODY") return findParents(node.parentNode, list);
-  else return list;
-};
+  if (node.tagName !== 'BODY') return findParents(node.parentNode, list)
+  else return list
+}
 
-const getEvents = node => {
-  if (!node) return null;
+const getEvents = (node) => {
+  if (!node) return null
   let handlers = Object.entries(node)
     .filter(([k]) => /^__reactProps/.test(k))
-    .map(p => p[1])
-    .shift();
+    .map((p) => p[1])
+    .shift()
   if (handlers && Object.keys(handlers).length) {
-    return handlers;
+    return handlers
   }
   handlers = Object.entries(node)
     .filter(([k]) => /^__reactEventHandlers/.test(k))
-    .filter(Boolean)[0];
-  if (!handlers) return null;
-  return handlers[1];
-};
+    .filter(Boolean)[0]
+  if (!handlers) return null
+  return handlers[1]
+}
 
-const merge = objs => {
-  const props = {};
+const merge = (objs) => {
+  const props = {}
   // Merge recursively
-  objs.forEach(obj => {
-    for (let key in obj) {
+  objs.forEach((obj) => {
+    for (const key in obj) {
       if (props[key]) {
-        for (let subKey in obj[key]) {
-          props[key][subKey] = obj[key][subKey];
+        for (const subKey in obj[key]) {
+          props[key][subKey] = obj[key][subKey]
         }
       } else {
-        props[key] = obj[key];
+        props[key] = obj[key]
       }
     }
-  });
-  return props;
-};
+  })
+  return props
+}
 
 const createEvent = (type, ...objs) => {
-  const props = merge(objs);
-  const event = new Event(type);
-  for (let key in props) {
+  const props = merge(objs)
+  const event = new Event(type)
+  for (const key in props) {
     Object.defineProperty(event, key, {
       value: props[key],
       enumerable: true,
       configurable: true
-    });
+    })
   }
-  return event;
-};
+  return event
+}
 
-$.prototype.trigger = function(type, time = 0, extra = {}) {
-  const propName = `on${type[0].toUpperCase() + type.slice(1)}`;
+$.prototype.trigger = function (type, time = 0, extra = {}) {
+  const propName = `on${type[0].toUpperCase() + type.slice(1)}`
   return act(async () => {
     await Promise.all(
-      this.map(async target => {
-        const parents = findParents(target);
+      this.map(async (target) => {
+        const parents = findParents(target)
 
         // The events manually registered on the root element
         if (this.events && this.events[type]) {
-          const currentTarget = parents[parents.length - 1];
-          const event = createEvent(type, target, { ...extra, currentTarget });
-          this.events[type].map(cb => cb(event));
+          const currentTarget = parents[parents.length - 1]
+          const event = createEvent(type, target, { ...extra, currentTarget })
+          this.events[type].map((cb) => cb(event))
         }
 
         // If there's a direct way of calling it e.g. `button.click()`
         if (target[type]) {
-          target[type](createEvent(type, target, extra));
+          target[type](createEvent(type, target, extra))
         } else {
           await Promise.all(
             parents
-              .map(el => [getEvents(el), el])
-              .filter(ev => ev[0])
-              .map(evts => [evts[0][propName], evts[1]])
-              .filter(evts => evts[0])
+              .map((el) => [getEvents(el), el])
+              .filter((ev) => ev[0])
+              .map((evts) => [evts[0][propName], evts[1]])
+              .filter((evts) => evts[0])
               .map(([cb, el]) => cb(createEvent(type, el, extra)))
-          );
+          )
         }
       })
-    );
-    await new Promise(done => setTimeout(done, time));
-  });
-};
+    )
+    await new Promise((resolve) => setTimeout(resolve, time))
+  })
+}

--- a/src/methods/type/index.js
+++ b/src/methods/type/index.js
@@ -1,10 +1,10 @@
-import $ from "../constructor";
+import $ from '../constructor'
 
 // Right now this is forced to be async just for the sake of it (from trigger).
 // This is because I'm fairly confident the final API will be async
-$.prototype.type = function(value) {
+$.prototype.type = function (value) {
   // const selector = args.find(a => typeof a === "string");
   // const time = args.find(a => typeof a === "number");
   // console.log(this.nodes);
-  return this.trigger("change", 0, { target: { value } });
-};
+  return this.trigger('change', 0, { target: { value } })
+}

--- a/src/methods/type/test.js
+++ b/src/methods/type/test.js
@@ -1,50 +1,50 @@
-import React, { useState } from "react";
-import $ from "../../";
-import "babel-polyfill";
+import React, { useState } from 'react'
+import $ from '../../'
+import 'babel-polyfill'
 
-describe(".type()", () => {
-  it("handles a simple input", async () => {
+describe('.type()', () => {
+  it('handles a simple input', async () => {
     const Input = () => {
-      const [text, setText] = useState("");
-      return <input value={text} onChange={e => setText(e.target.value)} />;
-    };
-    const $input = $(<Input />);
-    expect($input).toHaveValue("");
-    await $input.type("Francisco");
-    expect($input).toHaveValue("Francisco");
-  });
+      const [text, setText] = useState('')
+      return <input value={text} onChange={e => setText(e.target.value)} />
+    }
+    const $input = $(<Input />)
+    expect($input).toHaveValue('')
+    await $input.type('Francisco')
+    expect($input).toHaveValue('Francisco')
+  })
 
-  it("can attach and click on children", async () => {
-    const onChange = jest.fn();
-    const $input = $(<input onChange={onChange} />);
-    expect(onChange).not.toBeCalled();
-    await $input.type("Hello");
-    expect(onChange).toBeCalled();
+  it('can attach and click on children', async () => {
+    const onChange = jest.fn()
+    const $input = $(<input onChange={onChange} />)
+    expect(onChange).not.toBeCalled()
+    await $input.type('Hello')
+    expect(onChange).toBeCalled()
     expect(onChange.mock.calls[0][0]).toMatchObject({
-      target: { value: "Hello" }
-    });
-  });
+      target: { value: 'Hello' }
+    })
+  })
 
   const Greeter = () => {
-    const [name, setName] = useState("");
+    const [name, setName] = useState('')
     return (
       <div>
-        Hello {name || "Anonymous"}
+        Hello {name || 'Anonymous'}
         <input value={name} onChange={e => setName(e.target.value)} />
       </div>
-    );
-  };
-  it("can type in an input", async () => {
-    const $greet = $(<Greeter />);
-    expect($greet.text()).toBe("Hello Anonymous");
-    await $greet.find("input").type("Francisco");
-    expect($greet.text()).toBe("Hello Francisco");
-  });
+    )
+  }
+  it('can type in an input', async () => {
+    const $greet = $(<Greeter />)
+    expect($greet.text()).toBe('Hello Anonymous')
+    await $greet.find('input').type('Francisco')
+    expect($greet.text()).toBe('Hello Francisco')
+  })
 
   it("can use Jest's matcher", async () => {
-    const $input = $(<Greeter />).find("input");
-    expect($input).toHaveValue("");
-    await $input.type("Francisco");
-    expect($input).toHaveValue("Francisco");
-  });
-});
+    const $input = $(<Greeter />).find('input')
+    expect($input).toHaveValue('')
+    await $input.type('Francisco')
+    expect($input).toHaveValue('Francisco')
+  })
+})

--- a/src/methods/unique/index.js
+++ b/src/methods/unique/index.js
@@ -1,12 +1,12 @@
 // [INTERNAL USE ONLY]
-import $ from "../constructor";
+import $ from '../constructor'
 
 // Removed duplicated nodes, used for some specific methods
-$.prototype.unique = function() {
-  const nodes = [];
+$.prototype.unique = function () {
+  const nodes = []
   this.toArray().forEach(node => {
-    if (nodes.includes(node)) return;
-    nodes.push(node);
-  });
-  return $(nodes, this);
-};
+    if (nodes.includes(node)) return
+    nodes.push(node)
+  })
+  return $(nodes, this)
+}


### PR DESCRIPTION
I noticed many unintended styling changes in my last pull request, and subsequently noticed there were no styling guidelines for the project. I added the [JavaScript Standard Style](https://standardjs.com/) style guide, linter, and code formatter to the project, as well as a Style Guide section to the Contributing.md file with instructions on running it. I thought it would be a good idea for the project to have a consistent style guide and thought this would be a very simple option. 

Included in this pull request are all of the required style changes to pass the Standard styling requirements. I believe we could also add this as a GitHub action to require all pull requests to pass before being merged.