### PR TITLE
#45-Updating-Contributing-Guides

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -34,7 +34,7 @@ To allow for more people to get started as contributors, please limit your contr
 You can follow some of the existing methods in src/[METHOD]. We'd recommended to copy one of the existing ones and modify the files to have a base to get started, like `.children()`.
 
 ## Writing Code
-1. Create a local branch of the repository
+1. Create a local branch of the repository (alternatively you could use the "fork" menu to create your own copy of the repository)
 2. Copy an existing component folder (such as '.children()') from the existing modules in /src
 3. Rename the folder to match the name defined in the Issue you took from the Issues tab in Github.
 4. Write your implementation in the "index.js" file
@@ -42,6 +42,6 @@ You can follow some of the existing methods in src/[METHOD]. We'd recommended to
 6. Write tests for your function in the "test.js" file (More info on writing tests in the [Testing How-To](./contributing-guides/how-tos/Testing.md))
 
 ## Merging Your Contribution
-Once you have completed a code contribution you need to first create a branch on origin.  This may require getting permission from the repository owner.
-Once your branch is pushed to origin you can initiate a pull request.  To do so simply go to the Pull Requests tab in Github and click "New Pull Request".  Make a request to merge your branch to main and make sure to link the Issue you claimed in the PR description.  The project owner will review the PR.  Keep an eye out for feedback/comments on your PR to know if you need to make additional changes to allow your contribution to merge. 
+If you forked your own version of the repository, you will be able to make a Pull Request from your fork to the main fork.  If you create a local branch from the main repository, you may need to get permission from the repository owner in order to push your changes to your branch on origin.
+Once your branch is pushed to origin (or main in your fork) you can initiate a pull request.  To do so simply go to the Pull Requests tab in Github and click "New Pull Request".  Make a request to merge your branch to main and make sure to link the Issue you claimed in the PR description.  The project owner will review the PR.  Keep an eye out for feedback/comments on your PR to know if you need to make additional changes to allow your contribution to merge. 
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -2,70 +2,46 @@
 
 Thanks for contributing! We are actively looking for people who want to get started contributing to Open Source. Please feel free to open issues with questions or ask for clarification.
 
-To get started contributing, first you have to get the repo working in your computer. We recommend following this guide:
+Documentation for contributing can be found in the [contributing-guides folder](./contributing-guides).  If you are new to React Test a "Getting Started" guide follows.
+If you are looking for specific [How-To's](./contributing-guides/how-to), [Referece Docs](./contributing-guides/reference) or [In-Depth Explanations](./contributing-guides/explanations) check-out the corresponding folder our contributing guides.
 
-[**A Step by Step Guide to Making Your First GitHub Contribution**](https://codeburst.io/a-step-by-step-guide-to-making-your-first-github-contribution-5302260a2940).
+[_ToC_]
 
-Once you have the repository in your computer, access the folder from your terminal and finish the installation with Node.js:
+# Getting Started
+Contributing to React Test is a pretty simple process.
+1. [Clone the repository](#cloning-react-test)
+2. Find something to work on in the Issues tab and [Claim an issue](#finding-an-issue)
+3. [Write an implementation](#writing-code) that satisfies the requirements outlined in that issue
+4. [Initiate a Pull Request](#merging-your-contribution) from your branch 
 
-1. Install the dependencies: `npm install`
-1. Start watching the tests `npm start`
-1. Modify any file within `/src` (code or tests)
 
-This will run the tests on any change, making sure nothing breaks. Please try not to make a PR with broken tests (but if you cannot make it work, it's okay).
+## Cloning React Test
+To get started contributing, first you have to get the repo working in your computer:
 
-The documentation is a plain `readme.md` in the same folder as the code, and to see the websitet in the browser you can run:
+- Clone the repository: `git clone git://github.com/franciscop/react-test.git && cd ./react-test`
+- Install the dependencies: `npm install`
+- Start watching the tests `npm start`
+- Modify any file within `/src` (code, tests or documentation)
 
-1. For editing the documentation: `npm run docs`
+After these steps, the library, tests and documentation will be automatically built each time a change is saved. Please try not to make a PR with broken tests.
 
-This will run a local server, launch the browser page and rebuild+reload when any `readme.md` changes.
+## Finding an Issue
 
-## New methods
+This project organizes To-Do items using the [Issues tab in Github](https://github.com/franciscop/react-test/issues). Please contribute to any of those, on a first come first served basis.
 
-There are currently some new methods [suggested in the issues](https://github.com/franciscop/react-test/labels/good%20first%20issue). Please contribute to any of those, on a first come first served basis.
-
-Every method is inside a single folder, and this folder contains 3 files:
-
-- `index.js`: the implementation of the method.
-- `test.js`: the javascript tests that will run with `npm start` and `npm test`.
-- `readme.md`: the documentation of the method including intro, parameters, examples, etc.
-
-To allow for more people to get started as contributors, please limit your contributions to **2 methods** (one per Pull Request). If you want more, please feel free to open an issue and I can give some slightly more difficult tasks.
+To allow for more people to get started as contributors, please limit your contributions to **2 methods**. If you want more, please feel free to open an issue and I can give some slightly more difficult tasks.
 
 You can follow some of the existing methods in src/[METHOD]. We'd recommended to copy one of the existing ones and modify the files to have a base to get started, like `.children()`.
 
-## Testing
+## Writing Code
+1. Create a local branch of the repository
+2. Copy an existing component folder (such as '.children()') from the existing modules in /src
+3. Rename the folder to match the name defined in the Issue you took from the Issues tab in Github.
+4. Write your implementation in the "index.js" file
+5. Document your implementation in the "readme.md" file
+6. Write tests for your function in the "test.js" file (More info on writing tests in the [Testing How-To](./contributing-guides/how-tos/Testing.md))
 
-Tests should make sure that the feature work, with some diverse examples if possible. The normal flow is defining some component to be tested, then execute some operation against it and assert the result:
+## Merging Your Contribution
+Once you have completed a code contribution you need to first create a branch on origin.  This may require getting permission from the repository owner.
+Once your branch is pushed to origin you can initiate a pull request.  To do so simply go to the Pull Requests tab in Github and click "New Pull Request".  Make a request to merge your branch to main and make sure to link the Issue you claimed in the PR description.  The project owner will review the PR.  Keep an eye out for feedback/comments on your PR to know if you need to make additional changes to allow your contribution to merge. 
 
-```js
-it("Has the correct html without selector", async () => {
-  const $hello = $(
-    <div>
-      <button>Hello</button>
-    </div>
-  );
-  expect($hello.children().first().nodeName).toBe("BUTTON");
-});
-```
-
-You can also keep it in a variable if you want to assert multiple things:
-
-```js
-it("Has the correct html without selector", async () => {
-  const $hello = $(
-    <div>
-      <button>Hello</button>
-    </div>
-  );
-  const $button = $hello.children();
-  expect($button.first().nodeName).toBe("BUTTON");
-  expect($button.text()).toBe("Hello");
-});
-```
-
-## About "up for grabs"
-
-I've been doing OSS for ~10 years and it has been immensely useful for me in many ways, so I'd love to help others get started. Reviewing the PRs is a bit more work than implementing the code myself, but that's not an issue as long as I can help others.
-
-I've done an "up for grabs" before with [Umbrella JS](https://umbrellajs.com/), and the experience has been quite good. Unfortunately I'm not supporting that project anymore so issues are not visible there.

--- a/contributing-guides/how-tos/Testing.md
+++ b/contributing-guides/how-tos/Testing.md
@@ -1,0 +1,29 @@
+﻿## Testing
+
+Tests should make sure that the feature works, with some diverse examples if possible. The normal flow is defining some component to be tested, then execute some operation against it and assert the result:
+
+```js
+it("Has the correct html without selector", async () => {
+  const $hello = $(
+    <div>
+      <button>Hello</button>
+    </div>
+  );
+  expect($hello.children().first().nodeName).toBe("BUTTON");
+});
+```
+
+You can also keep it in a variable if you want to assert multiple things:
+
+```js
+it("Has the correct html without selector", async () => {
+  const $hello = $(
+    <div>
+      <button>Hello</button>
+    </div>
+  );
+  const $button = $hello.children();
+  expect($button.children().first().nodeName).toBe("BUTTON");
+  expect($button.html()).toBe("<button>Hello</button>");
+});
+```


### PR DESCRIPTION
Updates to documentation around contributing.  Adds more step-by-step instructions for new contributors.  Removes section about non-existent "Up-For-Grabs".  Sets up reference folder with How-To's, including how-to on writing tests.
Resolves [Issue #45 ](https://github.com/franciscop/react-test/issues/45)